### PR TITLE
Misc plugin updates

### DIFF
--- a/kmmbridge/src/main/kotlin/FaktoryServerArtifactManager.kt
+++ b/kmmbridge/src/main/kotlin/FaktoryServerArtifactManager.kt
@@ -9,7 +9,13 @@ import java.io.File
 import java.io.IOException
 import java.time.Duration
 
-class FaktoryServerArtifactManager : ArtifactManager {
+class FaktoryServerArtifactManager(
+    faktoryReadKey: String?,
+    project: Project,
+) : ArtifactManager {
+
+    private val faktoryReadKey: String = faktoryReadKey ?: project.findStringProperty("FAKTORY_READ_KEY")
+    ?: error("Must provide faktoryReadKey as argument to factoryServer() or gradle property \"FAKTORY_READ_KEY\"")
 
     override fun deployArtifact(project: Project, zipFilePath: File): String {
         val fileName = obscureFileName(project, project.kmmBridgeVersion)
@@ -18,8 +24,7 @@ class FaktoryServerArtifactManager : ArtifactManager {
     }
 
     private fun deployUrl(project: Project, zipFileName: String): String {
-        val faktoryKey = project.faktoryReadKey ?: error("No Faktory key provided!")
-        return faktoryReadUrl(zipFileName, faktoryKey)
+        return faktoryReadUrl(zipFileName, faktoryReadKey)
     }
 
     private fun uploadArtifact(project: Project, zipFilePath: File, fileName: String) {
@@ -69,6 +74,4 @@ private val FAKTORY_SERVER = if (isDev) {
     "https://api.touchlab.dev"
 }
 
-private val Project.faktoryReadKey: String?
-    get() = project.kmmBridgeExtension.faktoryReadKey.orNull ?: findStringProperty("FAKTORY_READ_KEY")
 private val Project.faktorySecretKey: String? get() = findStringProperty("FAKTORY_SECRET_KEY")

--- a/kmmbridge/src/main/kotlin/MultiRepoCocoapodsDependencyManager.kt
+++ b/kmmbridge/src/main/kotlin/MultiRepoCocoapodsDependencyManager.kt
@@ -15,7 +15,7 @@ class MultiRepoCocoapodsDependencyManager(
     private val specRepo: SpecRepo,
     private val allowWarnings: Boolean = true
 ) : DependencyManager {
-    override fun doExtraConfiguration(project: Project, uploadTask: Task, publishRemoteTask: Task) {
+    override fun configure(project: Project, uploadTask: Task, publishRemoteTask: Task) {
 
         val podSpecFile =
             "${project.buildDir}/XCFrameworks/${project.kmmBridgeExtension.buildType.get().name.toLowerCase()}/${project.kotlin.cocoapods.name}.podspec"

--- a/kmmbridge/src/main/kotlin/SpmDependencyManager.kt
+++ b/kmmbridge/src/main/kotlin/SpmDependencyManager.kt
@@ -18,7 +18,7 @@ class SpmDependencyManager(
     private val swiftPackageFilePath: String
         get() = "${stripEndSlash(swiftPackageFolder)}/Package.swift"
 
-    override fun doExtraConfiguration(project: Project, uploadTask: Task, publishRemoteTask: Task) {
+    override fun configure(project: Project, uploadTask: Task, publishRemoteTask: Task) {
         val updatePackageSwiftTask = project.task("updatePackageSwift") {
             group = TASK_GROUP_NAME
             val zipFile = project.zipFilePath()


### PR DESCRIPTION
- Move faktory read key from top-level to parameter of artifact manager (fixes #7)
- Remove default artifact manager configuration (fixes #26)
- Rename `DependencyManager.doExtraConfiguration()` to `configure()`
- Rename `publishRemoteFramework` gradle task to `kmmBridgePublish` (fixes old repo #197)