### PR TITLE
Version manager writes version tags

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ android.useAndroidX=true
 org.gradle.jvmargs=-Xmx2g
 
 GROUP=co.touchlab.faktory
-VERSION_NAME=0.1.14-devtest-SNAPSHOT
+VERSION_NAME=0.1.16-SNAPSHOT
 KOTLIN_VERSION=1.6.21
 
 POM_URL=https://github.com/touchlab/KMMBridge

--- a/kmmbridge/src/main/kotlin/GitReleaseVersionManager.kt
+++ b/kmmbridge/src/main/kotlin/GitReleaseVersionManager.kt
@@ -1,0 +1,18 @@
+package co.touchlab.faktory
+
+import co.touchlab.faktory.internal.GithubCalls
+import co.touchlab.faktory.internal.procRunFailLog
+import org.gradle.api.Project
+
+object GitReleaseVersionManager : GitTagBasedVersionManager() {
+    private var versionRecorded = false
+
+    override fun recordVersion(project: Project, versionString: String) {
+        if(!versionRecorded) {
+            project.procRunFailLog("git", "push")
+            val commitId = project.procRunFailLog("git", "rev-parse", "HEAD").first()
+            GithubCalls.createRelease(project, project.githubRepo, versionString, commitId)
+            versionRecorded = true
+        }
+    }
+}

--- a/kmmbridge/src/main/kotlin/GitTagBasedVersionManager.kt
+++ b/kmmbridge/src/main/kotlin/GitTagBasedVersionManager.kt
@@ -1,0 +1,20 @@
+package co.touchlab.faktory
+
+import co.touchlab.faktory.internal.procRun
+import co.touchlab.faktory.internal.procRunWarnLog
+import org.gradle.api.Project
+
+abstract class GitTagBasedVersionManager: VersionManager {
+    override fun getVersion(project: Project, versionPrefix: String): String {
+        val tagSet = mutableSetOf<String>()
+        // Need to make sure we have all the tags. This may need to be configurable in the future for
+        // more complex git setups. If call fails, we'll get a warning but keep going.
+        project.procRunWarnLog("git", "pull", "--tags")
+        procRun("git", "tag") { line, _ ->
+            tagSet.add(line)
+        }
+        return findNextVersion(versionPrefix) {
+            tagSet.contains(it)
+        }
+    }
+}

--- a/kmmbridge/src/main/kotlin/GitTagVersionManager.kt
+++ b/kmmbridge/src/main/kotlin/GitTagVersionManager.kt
@@ -1,21 +1,11 @@
 package co.touchlab.faktory
 
-import co.touchlab.faktory.co.touchlab.faktory.internal.procRun
-import co.touchlab.faktory.co.touchlab.faktory.internal.procRunFailLog
-import co.touchlab.faktory.co.touchlab.faktory.internal.procRunWarnLog
+import co.touchlab.faktory.internal.procRunFailLog
 import org.gradle.api.Project
 
-object GitTagVersionManager : VersionManager {
-    override fun getVersion(project: Project, versionPrefix: String): String {
-        val tagSet = mutableSetOf<String>()
-        // Need to make sure we have all of the tags. This may need to be configurable in the future for
-        // more complex git setups. If call fails, we'll get a warning but keep going.
-        project.procRunWarnLog("git", "pull", "--tags")
-        procRun("git", "tag") { line, _ ->
-            tagSet.add(line)
-        }
-        return findNextVersion(versionPrefix) {
-            tagSet.contains(it)
-        }
+object GitTagVersionManager : GitTagBasedVersionManager() {
+    override fun recordVersion(project: Project, versionString: String) {
+        project.procRunFailLog("git", "tag", "-a", versionString, "-m", "KMM release version $versionString")
+        project.procRunFailLog("git", "push", "--follow-tags")
     }
 }

--- a/kmmbridge/src/main/kotlin/GithubReleaseArtifactManager.kt
+++ b/kmmbridge/src/main/kotlin/GithubReleaseArtifactManager.kt
@@ -1,6 +1,6 @@
 package co.touchlab.faktory
 
-import co.touchlab.faktory.co.touchlab.faktory.internal.GithubCalls
+import co.touchlab.faktory.internal.GithubCalls
 import org.gradle.api.Project
 import java.io.File
 

--- a/kmmbridge/src/main/kotlin/GithubReleaseVersionManager.kt
+++ b/kmmbridge/src/main/kotlin/GithubReleaseVersionManager.kt
@@ -1,12 +1,12 @@
 package co.touchlab.faktory
 
-import co.touchlab.faktory.co.touchlab.faktory.internal.GithubCalls
+import co.touchlab.faktory.internal.GithubCalls
+import co.touchlab.faktory.internal.procRunFailLog
 import org.gradle.api.Project
 
-class GithubReleaseVersionManager() : VersionManager {
-    override fun getVersion(project: Project, versionPrefix: String): String {
-        return findNextVersion(versionPrefix) {
-            GithubCalls.findReleaseId(project, project.githubRepo, it) != null
-        }
+class GithubReleaseVersionManager() : GitTagBasedVersionManager() {
+    override fun recordVersion(project: Project, versionString: String) {
+        val commitId = project.procRunFailLog("git", "rev-parse", "HEAD").first()
+        GithubCalls.createRelease(project, project.githubRepo, versionString, commitId)
     }
 }

--- a/kmmbridge/src/main/kotlin/ManualVersionManager.kt
+++ b/kmmbridge/src/main/kotlin/ManualVersionManager.kt
@@ -7,4 +7,7 @@ import org.gradle.api.Project
  */
 object ManualVersionManager : VersionManager {
     override fun getVersion(project: Project, versionPrefix: String): String = versionPrefix
+    override fun recordVersion(project: Project, versionString: String) {
+        // Not needed
+    }
 }

--- a/kmmbridge/src/main/kotlin/TimestampVersionManager.kt
+++ b/kmmbridge/src/main/kotlin/TimestampVersionManager.kt
@@ -5,4 +5,8 @@ import org.gradle.api.Project
 object TimestampVersionManager : VersionManager {
     override fun getVersion(project: Project, versionPrefix: String): String =
         "${versionPrefix}.${System.currentTimeMillis()}"
+
+    override fun recordVersion(project: Project, versionString: String) {
+        // Not needed
+    }
 }

--- a/kmmbridge/src/main/kotlin/internal/GithubCalls.kt
+++ b/kmmbridge/src/main/kotlin/internal/GithubCalls.kt
@@ -1,4 +1,4 @@
-package co.touchlab.faktory.co.touchlab.faktory.internal
+package co.touchlab.faktory.internal
 
 import co.touchlab.faktory.*
 import co.touchlab.faktory.githubPublishToken

--- a/kmmbridge/src/main/kotlin/internal/ProcessHelper.kt
+++ b/kmmbridge/src/main/kotlin/internal/ProcessHelper.kt
@@ -1,4 +1,4 @@
-package co.touchlab.faktory.co.touchlab.faktory.internal
+package co.touchlab.faktory.internal
 
 import org.gradle.api.GradleException
 import org.gradle.api.Project


### PR DESCRIPTION
Ran into a little issue with tag versions. SPM was writing them, but if you only use Cocoapods, that won't work. Moved writing to the version manager.