### PR TITLE
Don't sign if RELEASE_SIGNING_ENABLED=false

### DIFF
--- a/kmmbridge/build.gradle.kts
+++ b/kmmbridge/build.gradle.kts
@@ -72,6 +72,8 @@ version = VERSION_NAME
 
 mavenPublishing {
     publishToMavenCentral()
-    signAllPublications()
+    val releaseSigningEnabled =
+        project.properties["RELEASE_SIGNING_ENABLED"]?.toString()?.equals("false", ignoreCase = true) != true
+    if (releaseSigningEnabled) signAllPublications()
     pomFromGradleProperties()
 }


### PR DESCRIPTION
I used to be able to pass `-PRELEASE_SIGNING_ENABLED=false` to skip signing when doing a local publish for testing. With the gradle plugin publishing changes, that stopped working.

This is a kludgy way to make it work again, but cc @TadeasKriz if you know a better way to do it.