### PR TITLE
Allow different framework name without extra config

### DIFF
--- a/kmmbridge/src/main/kotlin/KMMBridge.kt
+++ b/kmmbridge/src/main/kotlin/KMMBridge.kt
@@ -54,7 +54,7 @@ class KMMBridgePlugin : Plugin<Project> {
 
     // Collect all declared frameworks in project and combine into xcframework
     private fun Project.configureXcFramework() {
-        val extension = extensions.getByType<KmmBridgeExtension>()
+        val extension = kmmBridgeExtension
         var xcFrameworkConfig: XCFrameworkConfig? = null
 
         val spmBuildTargets: Set<String> = project.spmBuildTargets?.split(",")?.map { it.trim() }?.filter { it.isNotEmpty() }?.toSet() ?: emptySet()

--- a/kmmbridge/src/main/kotlin/KmmBridgeExtension.kt
+++ b/kmmbridge/src/main/kotlin/KmmBridgeExtension.kt
@@ -96,9 +96,8 @@ interface KmmBridgeExtension {
 
     fun Project.spm(
         spmDirectory: String? = null,
-        packageName: String = project.name,
     ) {
-        val dependencyManager = SpmDependencyManager(spmDirectory, packageName)
+        val dependencyManager = SpmDependencyManager(spmDirectory)
         dependencyManagers.set(dependencyManagers.getOrElse(emptyList()) + dependencyManager)
     }
 

--- a/kmmbridge/src/main/kotlin/dependencymanager/SpmDependencyManager.kt
+++ b/kmmbridge/src/main/kotlin/dependencymanager/SpmDependencyManager.kt
@@ -18,6 +18,7 @@ import co.touchlab.faktory.internal.procRunFailLog
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.kotlin.dsl.getByType
 import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -28,12 +29,12 @@ class SpmDependencyManager(
      * Folder where the Package.swift file lives
      */
     private val _swiftPackageFolder: String?,
-    private val packageName: String
 ) : DependencyManager {
     private fun Project.swiftPackageFolder(): String = _swiftPackageFolder ?: this.findRepoRoot()
     private fun Project.swiftPackageFilePath(): String = "${stripEndSlash(swiftPackageFolder())}/Package.swift"
 
     override fun configure(project: Project, uploadTask: Task, publishRemoteTask: Task) {
+        val extension = project.extensions.getByType<KmmBridgeExtension>()
         val updatePackageSwiftTask = project.task("updatePackageSwift") {
             group = TASK_GROUP_NAME
             val zipFile = project.zipFilePath()
@@ -44,8 +45,7 @@ class SpmDependencyManager(
                 override fun execute(t: Task) {
                     val checksum = project.findSpmChecksum(zipFile)
                     val url = project.urlFile.readText()
-
-                    project.writePackageFile(packageName, url, checksum)
+                    project.writePackageFile(extension.frameworkName.get(), url, checksum)
 
                     val version = project.versionFile.readText()
 
@@ -66,13 +66,19 @@ class SpmDependencyManager(
             @Suppress("ObjectLiteralToLambda")
             doLast(object : Action<Task> {
                 override fun execute(t: Task) {
-                    project.writePackageFile(makeLocalDevPackageFileText(project.swiftPackageFolder(), packageName, project))
+                    project.writePackageFile(
+                        makeLocalDevPackageFileText(
+                            project.swiftPackageFolder(),
+                            extension.frameworkName.get(),
+                            project
+                        )
+                    )
                 }
             })
         }
     }
 
-    private fun Project.writePackageFile(packageName: String, url: String, checksum: String){
+    private fun Project.writePackageFile(packageName: String, url: String, checksum: String) {
         val swiftPackageFile = file(swiftPackageFilePath())
         val packageText = makePackageFileText(packageName, url, checksum)
         swiftPackageFile.parentFile.mkdirs()
@@ -107,7 +113,7 @@ class SpmDependencyManager(
         return os.toByteArray().toString(Charset.defaultCharset()).trim()
     }
 
-    private fun Project.writePackageFile(data:String){
+    private fun Project.writePackageFile(data: String) {
         file(swiftPackageFilePath()).writeText(data)
     }
 
@@ -122,15 +128,16 @@ internal fun stripEndSlash(path: String): String {
     }
 }
 
-private fun makeLocalDevPackageFileText(swiftPackageFolder:String, packageName: String, project: Project): String {
+private fun makeLocalDevPackageFileText(swiftPackageFolder: String, frameworkName: String, project: Project): String {
     val swiftFolderPath = project.file(swiftPackageFolder).toPath()
     val projectFolderPath = project.projectDir.toPath()
-    val xcFrameworkPath = "${swiftFolderPath.relativize(projectFolderPath)}/build/XCFrameworks/${NativeBuildType.DEBUG.getName()}"
+    val xcFrameworkPath =
+        "${swiftFolderPath.relativize(projectFolderPath)}/build/XCFrameworks/${NativeBuildType.DEBUG.getName()}"
     val packageFileString = """
 // swift-tools-version:5.3
 import PackageDescription
 
-let packageName = "$packageName"
+let packageName = "$frameworkName"
 
 let package = Package(
     name: packageName,
@@ -156,7 +163,7 @@ let package = Package(
     return packageFileString
 }
 
-private fun makePackageFileText(packageName: String, url:String, checksum: String): String = """
+private fun makePackageFileText(packageName: String, url: String, checksum: String): String = """
 // swift-tools-version:5.3
 import PackageDescription
 

--- a/kmmbridge/src/main/kotlin/dependencymanager/SpmDependencyManager.kt
+++ b/kmmbridge/src/main/kotlin/dependencymanager/SpmDependencyManager.kt
@@ -34,7 +34,7 @@ class SpmDependencyManager(
     private fun Project.swiftPackageFilePath(): String = "${stripEndSlash(swiftPackageFolder())}/Package.swift"
 
     override fun configure(project: Project, uploadTask: Task, publishRemoteTask: Task) {
-        val extension = project.extensions.getByType<KmmBridgeExtension>()
+        val extension = project.kmmBridgeExtension
         val updatePackageSwiftTask = project.task("updatePackageSwift") {
             group = TASK_GROUP_NAME
             val zipFile = project.zipFilePath()


### PR DESCRIPTION
Use framework name from extension when making the package.swift file instead of the project name, remove packageName param to spm