### PR TITLE
PoC Integration Test workflow

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -31,8 +31,8 @@ jobs:
       - name: "Checkout sample"
         uses: actions/checkout@v3
         with:
-          repository: "touchlab/${{ matrix.target }}"
-          path: "build/${{ matrix.target }}"
+          repository: "touchlab/${{ matrix.sample }}"
+          path: "build/${{ matrix.sample }}"
 
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
@@ -64,21 +64,21 @@ jobs:
 
       - name: Publish shared
         run: |
-          cd build/${{ matrix.target }}
+          cd build/${{ matrix.sample }}
           ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.GITHUB_TOKEN }} -PGITHUB_REPO=${{ github.repository }} ${{ secrets.gradle_params }} --no-daemon --stacktrace
         env:
           GRADLE_OPTS: -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=512m"
 
       - name: Build SPM Sample
         run: |
-          cd build/${{ matrix.target }}/ios-spm
-          xcodebuild -configuration Debug -scheme ${{ matrix.target }}Spm -sdk iphonesimulator 
+          cd build/${{ matrix.sample }}/ios-spm
+          xcodebuild -configuration Debug -scheme ${{ matrix.sample }}Spm -sdk iphonesimulator 
 
       - name: Build Cocoapods Sample
         run: |
-          cd build/${{ matrix.target }}/ios-cocoapods
+          cd build/${{ matrix.sample }}/ios-cocoapods
           pod install
-          xcodebuild -workspace ${{ matrix.target }}Cocoapods.xcworkspace -configuration Debug -scheme ${{ matrix.target }}Cocoapods -sdk iphonesimulator 
+          xcodebuild -workspace ${{ matrix.sample }}Cocoapods.xcworkspace -configuration Debug -scheme ${{ matrix.sample }}Cocoapods -sdk iphonesimulator 
         
         
         

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -49,13 +49,13 @@ jobs:
         with:
           machine: api.github.com
           username: "cirunner"
-          password: ${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }}
+          password: ${{ github.token }}
 
       - uses: extractions/netrc@v1
         with:
           machine: maven.pkg.github.com
           username: "cirunner"
-          password: ${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }}
+          password: ${{ github.token }}
 
       - name: Cache build tooling
         uses: actions/cache@v2
@@ -72,7 +72,7 @@ jobs:
       - name: Publish shared
         run: |
           cd build/${{ matrix.sample }}
-          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }} -PGITHUB_REPO=${{ matrix.sample }} ${{ secrets.gradle_params }} --no-daemon --stacktrace
+          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ github.token }} -PGITHUB_REPO=${{ matrix.sample }} ${{ secrets.gradle_params }} --no-daemon --stacktrace
         env:
           GRADLE_OPTS: -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=512m"
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -34,7 +34,6 @@ jobs:
           repository: "${{ matrix.sample }}"
           ref: main
           path: "build/${{ matrix.sample }}"
-          token: ${{ github.token }}
 
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
@@ -63,14 +62,21 @@ jobs:
       - name: Local publish plugin
         run: |
           ./gradlew publishToMavenLocal -PRELEASE_SIGNING_ENABLED=false -PVERSION_NAME=999
-          
-      - name: Run sample tests
-        env:
-          ORG_GRADLE_PROJECT_GITHUB_PUBLISH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ORG_GRADLE_PROJECT_GITHUB_REPO: ${{ matrix.sample }}
+
+      - name: Publish shared
         run: |
           cd build/${{ matrix.sample }}
-          ./run_tests.sh
-        
-        
-        
+          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.GITHUB_TOKEN }} -PGITHUB_REPO=${{ github.repository }} ${{ secrets.gradle_params }} --no-daemon --stacktrace
+        env:
+          GRADLE_OPTS: -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=512m"
+
+      - name: Build SPM Sample
+        run: |
+          cd build/${{ matrix.sample }}/ios-spm
+          xcodebuild -configuration Debug -scheme ${{ matrix.sample }}Spm -sdk iphonesimulator 
+
+      - name: Build Cocoapods Sample
+        run: |
+          cd build/${{ matrix.sample }}/ios-cocoapods
+          pod install
+          xcodebuild -workspace ${{ matrix.sample }}Cocoapods.xcworkspace -configuration Debug -scheme ${{ matrix.sample }}Cocoapods -sdk iphonesimulator 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,9 +16,11 @@ on:
 jobs:
   build:
     runs-on: macos-12
+    env:
+      GITHUB_PUBLISH_USER: "russhwolf" # TODO convert this to a CI user and generate a new PAT
     strategy:
       matrix:
-        sample: [ KmmBridgeIntegrationTest ] # TODO add other samples here.
+        sample: [ KmmBridgeIntegrationTest, KmmBridgeIntegrationTest-GithubReleases ]
 
     steps:
       - uses: actions/checkout@v3
@@ -45,18 +47,19 @@ jobs:
         with:
           ssh-private-key: |
             ${{ secrets.PODSPEC_SSH_KEY }}
-            ${{ secrets.REPO_SSH_KEY }}
+            ${{ secrets.INTEGRATION_TEST_MAVEN_PUBLISH_SSH_KEY" }}
+            ${{ secrets.INTEGRATION_TEST_GITHUB_RELEASES_SSH_KEY" }}
 
       - uses: extractions/netrc@v1
         with:
           machine: api.github.com
-          username: "russhwolf"
+          username: ${{ env.GITHUB_PUBLISH_USER }}
           password: ${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }}
 
       - uses: extractions/netrc@v1
         with:
           machine: maven.pkg.github.com
-          username: "russhwolf"
+          username: ${{ env.GITHUB_PUBLISH_USER }}
           password: ${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }}
 
       - name: Cache build tooling
@@ -67,6 +70,7 @@ jobs:
             ~/.konan
           key: ${{ runner.os }}-v4-${{ hashFiles('*.gradle.kts') }}
 
+      # TODO can we cache this so it only runs once instead of running for every test case?
       - name: Local publish plugin
         run: |
           ./gradlew publishToMavenLocal -PRELEASE_SIGNING_ENABLED=false -PVERSION_NAME=999
@@ -74,17 +78,17 @@ jobs:
       - name: Publish shared
         run: |
           cd build/${{ matrix.sample }}
-          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }} -PGITHUB_REPO=touchlab/${{ matrix.sample }} -PGITHUB_PUBLISH_USER=russhwolf ${{ secrets.gradle_params }} --no-daemon --stacktrace
+          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }} -PGITHUB_REPO=touchlab/${{ matrix.sample }} -PGITHUB_PUBLISH_USER=${{ env.GITHUB_PUBLISH_USER }} --no-daemon --stacktrace
         env:
           GRADLE_OPTS: -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=512m"
 
       - name: Build SPM Sample
         run: |
           cd build/${{ matrix.sample }}/ios-spm
-          xcodebuild -configuration Debug -scheme ${{ matrix.sample }}Spm -sdk iphonesimulator 
+          xcodebuild -configuration Debug -scheme KmmBridgeIntegrationTestSpm -sdk iphonesimulator 
 
       - name: Build Cocoapods Sample
         run: |
           cd build/${{ matrix.sample }}/ios-cocoapods
           pod install
-          xcodebuild -workspace ${{ matrix.sample }}Cocoapods.xcworkspace -configuration Debug -scheme ${{ matrix.sample }}Cocoapods -sdk iphonesimulator 
+          xcodebuild -workspace KmmBridgeIntegrationTestCocoapods.xcworkspace -configuration Debug -scheme KmmBridgeIntegrationTestCocoapods -sdk iphonesimulator 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -43,20 +43,20 @@ jobs:
           min-wrapper-count: 2 # Validating both the local wrapper and the one in the cloned sample
 
       - name: Apply SSH Key
-        uses: webfactory/ssh-agent@v0.5.4
+        uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # v0.7.0
         with:
           ssh-private-key: |
             ${{ secrets.PODSPEC_SSH_KEY }}
             ${{ secrets.INTEGRATION_TEST_MAVEN_PUBLISH_SSH_KEY }}
             ${{ secrets.INTEGRATION_TEST_GITHUB_RELEASES_SSH_KEY }}
 
-      - uses: extractions/netrc@v1
+      - uses: extractions/netrc@938ddbfb73b4efee33e57db13aba434b35af2f93 # v1
         with:
           machine: api.github.com
           username: ${{ env.GITHUB_PUBLISH_USER }}
           password: ${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }}
 
-      - uses: extractions/netrc@v1
+      - uses: extractions/netrc@938ddbfb73b4efee33e57db13aba434b35af2f93 # v1
         with:
           machine: maven.pkg.github.com
           username: ${{ env.GITHUB_PUBLISH_USER }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -43,7 +43,9 @@ jobs:
       - name: Apply SSH Key
         uses: webfactory/ssh-agent@v0.5.4
         with:
-          ssh-private-key: ${{ secrets.PODSPEC_SSH_KEY }}
+          ssh-private-key: |
+            ${{ secrets.PODSPEC_SSH_KEY }}
+            ${{ secrets.REPO_SSH_KEY }}
 
       - uses: extractions/netrc@v1
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        sample: [touchlab-lab/KmmBridgeIntegrationTest] # TODO add other samples here.
+        sample: [touchlab/KmmBridgeIntegrationTest] # TODO add other samples here.
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Publish shared
         run: |
           cd build/${{ matrix.sample }}
-          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.GITHUB_TOKEN }} -PGITHUB_REPO=${{ github.repository }} ${{ secrets.gradle_params }} --no-daemon --stacktrace
+          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }} -PGITHUB_REPO=${{ github.repository }} ${{ secrets.gradle_params }} --no-daemon --stacktrace
         env:
           GRADLE_OPTS: -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=512m"
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -47,8 +47,8 @@ jobs:
         with:
           ssh-private-key: |
             ${{ secrets.PODSPEC_SSH_KEY }}
-            ${{ secrets.INTEGRATION_TEST_MAVEN_PUBLISH_SSH_KEY" }}
-            ${{ secrets.INTEGRATION_TEST_GITHUB_RELEASES_SSH_KEY" }}
+            ${{ secrets.INTEGRATION_TEST_MAVEN_PUBLISH_SSH_KEY }}
+            ${{ secrets.INTEGRATION_TEST_GITHUB_RELEASES_SSH_KEY }}
 
       - uses: extractions/netrc@v1
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -48,13 +48,13 @@ jobs:
       - uses: extractions/netrc@v1
         with:
           machine: api.github.com
-          username: "cirunner"
+          username: "russhwolf"
           password: ${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }}
 
       - uses: extractions/netrc@v1
         with:
           machine: maven.pkg.github.com
-          username: "cirunner"
+          username: "russhwolf"
           password: ${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }}
 
       - name: Cache build tooling

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,86 @@
+name: "Integration Test"
+
+on: 
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "**/*.md"
+      - "website/**"
+  pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "website/**"
+  workflow_dispatch:
+      
+jobs:
+  build:
+    runs-on: macos-12
+    strategy:
+      matrix:
+        sample: [KmmBridgeIntegrationTest] # TODO add other samples here.
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "adopt"
+          java-version: "11"
+      
+      - name: "Checkout sample"
+        uses: actions/checkout@v3
+        with:
+          repository: "touchlab/${{ matrix.target }}"
+          path: "build/${{ matrix.target }}"
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+        with:
+          min-wrapper-count: 2 # Validating both the local wrapper and the one in the cloned sample
+
+      - name: Apply SSH Key
+        uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.PODSPEC_SSH_KEY }}
+
+      - uses: extractions/netrc@v1
+        with:
+          machine: api.github.com
+          username: "cirunner"
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache build tooling
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.konan
+          key: ${{ runner.os }}-v4-${{ hashFiles('*.gradle.kts') }}
+
+      - name: Local publish plugin
+        run: |
+          ./gradlew publishToMavenLocal -PRELEASE_SIGNING_ENABLED=false -PVERSION_NAME=999
+
+      - name: Publish shared
+        run: |
+          cd build/${{ matrix.target }}
+          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.GITHUB_TOKEN }} -PGITHUB_REPO=${{ github.repository }} ${{ secrets.gradle_params }} --no-daemon --stacktrace
+        env:
+          GRADLE_OPTS: -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=512m"
+
+      - name: Build SPM Sample
+        run: |
+          cd build/${{ matrix.target }}/ios-spm
+          xcodebuild -configuration Debug -scheme ${{ matrix.target }}Spm -sdk iphonesimulator 
+
+      - name: Build Cocoapods Sample
+        run: |
+          cd build/${{ matrix.target }}/ios-cocoapods
+          pod install
+          xcodebuild -workspace ${{ matrix.target }}Cocoapods.xcworkspace -configuration Debug -scheme ${{ matrix.target }}Cocoapods -sdk iphonesimulator 
+        
+        
+        
+        
+        

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        sample: [touchlab/KmmBridgeIntegrationTest] # TODO add other samples here.
+        sample: [ KmmBridgeIntegrationTest ] # TODO add other samples here.
 
     steps:
       - uses: actions/checkout@v3
@@ -31,7 +31,7 @@ jobs:
       - name: "Checkout sample"
         uses: actions/checkout@v3
         with:
-          repository: "${{ matrix.sample }}"
+          repository: "touchlab/${{ matrix.sample }}"
           ref: main
           path: "build/${{ matrix.sample }}"
 
@@ -74,7 +74,7 @@ jobs:
       - name: Publish shared
         run: |
           cd build/${{ matrix.sample }}
-          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }} -PGITHUB_REPO=${{ matrix.sample }} -PGITHUB_PUBLISH_USER=russhwolf ${{ secrets.gradle_params }} --no-daemon --stacktrace
+          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }} -PGITHUB_REPO=touchlab/${{ matrix.sample }} -PGITHUB_PUBLISH_USER=russhwolf ${{ secrets.gradle_params }} --no-daemon --stacktrace
         env:
           GRADLE_OPTS: -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=512m"
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Publish shared
         run: |
           cd build/${{ matrix.sample }}
-          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }} -PGITHUB_REPO=${{ matrix.sample }} ${{ secrets.gradle_params }} --no-daemon --stacktrace
+          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }} -PGITHUB_REPO=${{ matrix.sample }} -PGITHUB_PUBLISH_USER=russhwolf ${{ secrets.gradle_params }} --no-daemon --stacktrace
         env:
           GRADLE_OPTS: -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=512m"
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     runs-on: macos-12
     env:
-      GITHUB_PUBLISH_USER: "russhwolf" # TODO convert this to a CI user and generate a new PAT
+      GITHUB_PUBLISH_USER: "Touchlab-Bot"
     strategy:
       matrix:
         sample: [ KmmBridgeIntegrationTest, KmmBridgeIntegrationTest-GithubReleases ]

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -49,13 +49,13 @@ jobs:
         with:
           machine: api.github.com
           username: "cirunner"
-          password: ${{ github.token }}
+          password: ${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }}
 
       - uses: extractions/netrc@v1
         with:
           machine: maven.pkg.github.com
           username: "cirunner"
-          password: ${{ github.token }}
+          password: ${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }}
 
       - name: Cache build tooling
         uses: actions/cache@v2
@@ -72,7 +72,7 @@ jobs:
       - name: Publish shared
         run: |
           cd build/${{ matrix.sample }}
-          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ github.token }} -PGITHUB_REPO=${{ matrix.sample }} ${{ secrets.gradle_params }} --no-daemon --stacktrace
+          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }} -PGITHUB_REPO=${{ matrix.sample }} ${{ secrets.gradle_params }} --no-daemon --stacktrace
         env:
           GRADLE_OPTS: -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=512m"
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -34,7 +34,7 @@ jobs:
           repository: "touchlab/${{ matrix.sample }}"
           ref: main
           path: "build/${{ matrix.sample }}"
-          
+          token: ${{ github.token }}
 
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -32,7 +32,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: "touchlab/${{ matrix.sample }}"
+          ref: main
           path: "build/${{ matrix.sample }}"
+          
 
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        sample: [KmmBridgeIntegrationTest] # TODO add other samples here.
+        sample: [touchlab-lab/KmmBridgeIntegrationTest] # TODO add other samples here.
 
     steps:
       - uses: actions/checkout@v3
@@ -31,7 +31,7 @@ jobs:
       - name: "Checkout sample"
         uses: actions/checkout@v3
         with:
-          repository: "touchlab/${{ matrix.sample }}"
+          repository: "${{ matrix.sample }}"
           ref: main
           path: "build/${{ matrix.sample }}"
           token: ${{ github.token }}
@@ -63,26 +63,11 @@ jobs:
       - name: Local publish plugin
         run: |
           ./gradlew publishToMavenLocal -PRELEASE_SIGNING_ENABLED=false -PVERSION_NAME=999
-
-      - name: Publish shared
+          
+      - name: Run sample tests
         run: |
           cd build/${{ matrix.sample }}
-          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.GITHUB_TOKEN }} -PGITHUB_REPO=${{ github.repository }} ${{ secrets.gradle_params }} --no-daemon --stacktrace
-        env:
-          GRADLE_OPTS: -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=512m"
-
-      - name: Build SPM Sample
-        run: |
-          cd build/${{ matrix.sample }}/ios-spm
-          xcodebuild -configuration Debug -scheme ${{ matrix.sample }}Spm -sdk iphonesimulator 
-
-      - name: Build Cocoapods Sample
-        run: |
-          cd build/${{ matrix.sample }}/ios-cocoapods
-          pod install
-          xcodebuild -workspace ${{ matrix.sample }}Cocoapods.xcworkspace -configuration Debug -scheme ${{ matrix.sample }}Cocoapods -sdk iphonesimulator 
-        
-        
+          ./run_tests.sh
         
         
         

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           machine: maven.pkg.github.com
           username: "cirunner"
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }}
 
       - name: Cache build tooling
         uses: actions/cache@v2

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Publish shared
         run: |
           cd build/${{ matrix.sample }}
-          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }} -PGITHUB_REPO=${{ github.repository }} ${{ secrets.gradle_params }} --no-daemon --stacktrace
+          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }} -PGITHUB_REPO=${{ matrix.sample }} ${{ secrets.gradle_params }} --no-daemon --stacktrace
         env:
           GRADLE_OPTS: -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=512m"
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           machine: api.github.com
           username: "cirunner"
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }}
 
       - name: Cache build tooling
         uses: actions/cache@v2

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -51,6 +51,12 @@ jobs:
           username: "cirunner"
           password: ${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }}
 
+      - uses: extractions/netrc@v1
+        with:
+          machine: maven.pkg.github.com
+          username: "cirunner"
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Cache build tooling
         uses: actions/cache@v2
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -65,9 +65,9 @@ jobs:
           ./gradlew publishToMavenLocal -PRELEASE_SIGNING_ENABLED=false -PVERSION_NAME=999
           
       - name: Run sample tests
-        env: |
-          ORG_GRADLE_PROJECT_GITHUB_PUBLISH_TOKEN=${{ secrets.GITHUB_TOKEN }}
-          ORG_GRADLE_PROJECT_GITHUB_REPO=${{ matrix.sample }}
+        env:
+          ORG_GRADLE_PROJECT_GITHUB_PUBLISH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG_GRADLE_PROJECT_GITHUB_REPO: ${{ matrix.sample }}
         run: |
           cd build/${{ matrix.sample }}
           ./run_tests.sh

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        sample: [touchlab/KmmBridgeIntegrationTest] # TODO add other samples here.
+        sample: [touchlab-lab/KmmBridgeIntegrationTest] # TODO add other samples here.
 
     steps:
       - uses: actions/checkout@v3
@@ -65,6 +65,9 @@ jobs:
           ./gradlew publishToMavenLocal -PRELEASE_SIGNING_ENABLED=false -PVERSION_NAME=999
           
       - name: Run sample tests
+        env: |
+          ORG_GRADLE_PROJECT_GITHUB_PUBLISH_TOKEN=${{ secrets.GITHUB_TOKEN }}
+          ORG_GRADLE_PROJECT_GITHUB_REPO=${{ matrix.sample }}
         run: |
           cd build/${{ matrix.sample }}
           ./run_tests.sh


### PR DESCRIPTION
This is a workflow that calls out to other repos where our integration tests live. Right now there's one test case with `githubReleaseArtifacts()` and one with `mavenPublishArtifacts()`.

I left notes for how to add a new test case in the readme at https://github.com/touchlab/KmmBridgeIntegrationTest but there's probably a better place to put them once we're ready to merge this.