### PR TITLE
Generate XCFramework in Project's build directory.

### DIFF
--- a/kmmbridge/src/main/kotlin/dependencymanager/SpmDependencyManager.kt
+++ b/kmmbridge/src/main/kotlin/dependencymanager/SpmDependencyManager.kt
@@ -125,7 +125,7 @@ internal fun stripEndSlash(path: String): String {
 private fun makeLocalDevPackageFileText(swiftPackageFolder:String, packageName: String, project: Project): String {
     val swiftFolderPath = project.file(swiftPackageFolder).toPath()
     val projectFolderPath = project.projectDir.toPath()
-    val xcFrameworkPath = "${swiftFolderPath.relativize(projectFolderPath)}/build/XCFrameworks/${NativeBuildType.DEBUG.getName()}"
+    val xcFrameworkPath = "${swiftFolderPath.relativize(projectFolderPath)}/${project.buildDir}/XCFrameworks/${NativeBuildType.DEBUG.getName()}"
     val packageFileString = """
 // swift-tools-version:5.3
 import PackageDescription


### PR DESCRIPTION
Respect consumer project's build directory setting instead of assuming `build` naming.

Fixes #115.
