### PR TITLE
Finalize values once we set them on versionManager and artifactManager

### DIFF
--- a/kmmbridge/src/main/kotlin/KmmBridgeExtension.kt
+++ b/kmmbridge/src/main/kotlin/KmmBridgeExtension.kt
@@ -57,7 +57,7 @@ interface KmmBridgeExtension {
         makeArtifactsPublic: Boolean = true,
         altBaseUrl: String? = null,
     ) {
-        artifactManager.set(
+        artifactManager.setAndFinalize(
             AwsS3PublicArtifactManager(
                 region,
                 bucket,
@@ -72,11 +72,11 @@ interface KmmBridgeExtension {
     fun githubReleaseArtifacts(
         artifactRelease: String? = null
     ) {
-        artifactManager.set(GithubReleaseArtifactManager(artifactRelease))
+        artifactManager.setAndFinalize(GithubReleaseArtifactManager(artifactRelease))
     }
 
     fun Project.faktoryServerArtifacts(faktoryReadKey: String? = null) {
-        artifactManager.set(FaktoryServerArtifactManager(faktoryReadKey, this))
+        artifactManager.setAndFinalize(FaktoryServerArtifactManager(faktoryReadKey, this))
     }
 
     /**
@@ -84,23 +84,23 @@ interface KmmBridgeExtension {
      * passing the name in here.
      */
     fun Project.mavenPublishArtifacts(repository: String? = null, publication: String? = null) {
-        artifactManager.set(MavenPublishArtifactManager(this, publication, repository))
+        artifactManager.setAndFinalize(MavenPublishArtifactManager(this, publication, repository))
     }
 
     fun timestampVersions() {
-        versionManager.set(TimestampVersionManager)
+        versionManager.setAndFinalize(TimestampVersionManager)
     }
 
     fun gitTagVersions() {
-        versionManager.set(GitTagVersionManager)
+        versionManager.setAndFinalize(GitTagVersionManager)
     }
 
     fun githubReleaseVersions() {
-        versionManager.set(GithubReleaseVersionManager)
+        versionManager.setAndFinalize(GithubReleaseVersionManager)
     }
 
     fun manualVersions() {
-        versionManager.set(ManualVersionManager)
+        versionManager.setAndFinalize(ManualVersionManager)
     }
 
     fun Project.spm(
@@ -118,5 +118,10 @@ interface KmmBridgeExtension {
             SpecRepo.Private(specRepoUrl ?: "https://api:${githubPublishToken}@github.com/${githubRepo}")
         })
         dependencyManagers.set(dependencyManagers.getOrElse(emptyList()) + dependencyManager)
+    }
+
+    private fun <T> Property<T>.setAndFinalize(value: T) {
+        this.set(value)
+        this.finalizeValue()
     }
 }


### PR DESCRIPTION
Gradle properties allow you to "finalize" their value, and gradle will then automatically report a failure if someone attempts to mutate the value after that point - stopping the build and reporting the line number where the assignment is trying to happen.

This PR sets `versionManager` and `artifactManager` to final once their value is set in one of our configuration methods.  Closes #104  

```
Build file '<<some path>>/build.gradle.kts' line: 35

The value for extension 'kmmbridge' property 'artifactManager' is final and cannot be changed any further.

* Try:
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Exception is:
java.lang.IllegalStateException: The value for extension 'kmmbridge' property 'artifactManager' is final and cannot be changed any further.
```