### PR TITLE
Adjust secret name in CI

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -50,7 +50,7 @@ jobs:
             ${{ secrets.PODSPEC_SSH_KEY }}
             ${{ secrets.INTEGRATION_TEST_MAVEN_PUBLISH_SSH_KEY }}
             ${{ secrets.INTEGRATION_TEST_GITHUB_RELEASES_SSH_KEY }}
-            ${{ secrets.INTEGRATION_TEST_MavenGHPackages_GHReleaseVersions }}
+            ${{ secrets.INTEGRATION_TEST_MAVENGHPACKAGES_GHRELEASEVERSIONS }}
             ${{ secrets.INTEGRATION_TEST_GITHUB_RELEASE_VERSION_SSH_KEY }}
 
       - uses: extractions/netrc@938ddbfb73b4efee33e57db13aba434b35af2f93 # v1


### PR DESCRIPTION
I think this is why the integration tests are failing