### PR TITLE
Fix upload URL for Github Enterprise

### DIFF
--- a/kmmbridge/src/main/kotlin/internal/GithubEnterpriseCalls.kt
+++ b/kmmbridge/src/main/kotlin/internal/GithubEnterpriseCalls.kt
@@ -66,7 +66,7 @@ object GithubEnterpriseCalls {
 
         val uploadRequest = Request.Builder()
             .url(
-                "https://${host}/api/v3/repos/${owner}/${repo}/releases/${releaseId}/assets?name=${
+                "https://${host}/api/uploads/repos/${owner}/${repo}/releases/${releaseId}/assets?name=${
                     URLEncoder.encode(
                         fileName, "UTF-8"
                     )


### PR DESCRIPTION
Hello Touchlab. I just found a small issue with the endpoint for uploading artifacts while testing a new version of KMMBridge on our GitHub Enterprise-based project. This adjustment should fix the issue.