### PR TITLE
SPM local dev flow works for local branch

### DIFF
--- a/.github/workflows/integration-tests-local-branch-ok.yml
+++ b/.github/workflows/integration-tests-local-branch-ok.yml
@@ -56,11 +56,10 @@ jobs:
         run: |
           ./gradlew publishToMavenLocal -PRELEASE_SIGNING_ENABLED=false -PVERSION_NAME=999
 
-      - name: Run something with Gradle on local branch
+      - name: Run local dev flow
         run: |
           cd build/${{ matrix.sample }}
           git checkout -b mylocalbranch
-          ./gradlew tasks --info --no-daemon --stacktrace
+          ./gradlew spmDevBuild -PspmBuildTargets=ios_x64 --info --no-daemon --stacktrace
         env:
           GRADLE_OPTS: -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=512m"
-

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ android.useAndroidX=true
 org.gradle.jvmargs=-Xmx2g
 
 GROUP=co.touchlab.faktory
-VERSION_NAME=0.3.3
+VERSION_NAME=0.3.4-SNAPSHOT
 KOTLIN_VERSION=1.7.20
 
 POM_URL=https://github.com/touchlab/KMMBridge

--- a/kmmbridge/src/main/kotlin/KMMBridge.kt
+++ b/kmmbridge/src/main/kotlin/KMMBridge.kt
@@ -43,6 +43,7 @@ class KMMBridgePlugin : Plugin<Project> {
 
         afterEvaluate {
             configureXcFramework()
+            configureLocalDev()
             configureArtifactManagerAndDeploy()
         }
     }
@@ -88,6 +89,11 @@ class KMMBridgePlugin : Plugin<Project> {
                     xcFrameworkConfig!!.add(framework)
                 }
             }
+    }
+
+    private fun Project.configureLocalDev() {
+        val extension = kmmBridgeExtension
+        extension.localDevManager.orNull?.configureLocalDev(this)
     }
 
     private fun Project.configureArtifactManagerAndDeploy() {

--- a/kmmbridge/src/main/kotlin/KmmBridgeExtension.kt
+++ b/kmmbridge/src/main/kotlin/KmmBridgeExtension.kt
@@ -29,6 +29,7 @@ import co.touchlab.faktory.versionmanager.GithubReleaseVersionManager
 import co.touchlab.faktory.versionmanager.ManualVersionManager
 import co.touchlab.faktory.versionmanager.TimestampVersionManager
 import co.touchlab.faktory.versionmanager.VersionManager
+import localdevmanager.LocalDevManager
 import org.gradle.api.Project
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
@@ -44,6 +45,8 @@ interface KmmBridgeExtension {
     val dependencyManagers: ListProperty<DependencyManager>
 
     val artifactManager: Property<ArtifactManager>
+
+    val localDevManager: Property<LocalDevManager>
 
     val buildType: Property<NativeBuildType>
 
@@ -121,6 +124,7 @@ interface KmmBridgeExtension {
     ) {
         val dependencyManager = SpmDependencyManager(spmDirectory, commitManually)
         dependencyManagers.set(dependencyManagers.getOrElse(emptyList()) + dependencyManager)
+        localDevManager.setAndFinalize(dependencyManager)
     }
 
     /**

--- a/kmmbridge/src/main/kotlin/localdevmanager/LocalDevManager.kt
+++ b/kmmbridge/src/main/kotlin/localdevmanager/LocalDevManager.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022 Touchlab.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package localdevmanager
+
+import org.gradle.api.Project
+
+interface LocalDevManager {
+    fun configureLocalDev(project: Project)
+}


### PR DESCRIPTION
SPM local dev flow breaks on fix for local branch. Pulled out `LocalDevManager` abstraction to keep basic separation of concerns, but kept implementation in the `SpmDependencyManager` class for simplicity. We'll be moving this out of KMMBridge soon (likely), so a deeper refactor seemed kind of pointless.