### PR TITLE
[Issue-Faktory#319] Add mention of `commitManually` parameter in docs

### DIFF
--- a/website/docs/spm/01_IOS_SPM.md
+++ b/website/docs/spm/01_IOS_SPM.md
@@ -38,6 +38,23 @@ kmmbridge {
 }
 ```
 
+### Commit manually
+
+There is an option to disable git operations and commit the generated `Package.swift` by yourself.
+Typical usage would be when using `manualVersions()` or `timestampVersions()` to avoid all automatic git interaction.
+Using `commitManually` is somewhat dangerous, as the publication state is inconsistent at the end of the kmmBridgePublish task. 
+The user is responsible for manually committing the updated package file, or else the new version will not be available to downstream consumers.
+When using `gitTagVersions()` if you don't commit and tag the newest version, the next publishing might fail because the version is not incremented correctly.
+
+To do so set the `commitManually` parameter to `true`.
+
+```kotlin
+kmmbridge {
+    spm(commitManually = true)
+    // Other config...
+}
+```
+
 Once this is all set up, run a build so you have at least one version available.
 
 ## Artifact Authentication


### PR DESCRIPTION
Issue: https://github.com/touchlab/Faktory/issues/319

## Summary
Add info about the commitManually parameter to the website docs.
