### PR TITLE
[Issue-#179] Document passing custom netrc credentials to github workflow

### DIFF
--- a/website/docs/ciconfig/01_GITHUB_ACTIONS.md
+++ b/website/docs/ciconfig/01_GITHUB_ACTIONS.md
@@ -45,7 +45,7 @@ Notice the "on" section. In our example, you can run the workflow manually with 
 
 Then call our workflow:
 
-```yam
+```yaml
 jobs:
   call-kmmbridge-publish:
     uses: touchlab/KMMBridgeGithubWorkflow/.github/workflows/faktorybuildbranches.yml@v0.3
@@ -61,3 +61,32 @@ There are 2 parameters, both are optional:
 
 * gradle_params - If your Gradle build needs custom params, like properties, pass them here.
 * PODSPEC_SSH_KEY - The SSH key for publishing.
+
+When publishing in a CI action you need to add the credentials to `~/.netrc` before running publish to validate the podspec. To do this simply pass the custom `netrc` params in our GitHub Workflow.
+
+You'll also need to add the username and password gradle params through the `gradle_params` secret in our workflow:
+
+```yaml
+jobs:
+  call-kmmbridge-publish:
+    uses: touchlab/KMMBridgeGithubWorkflow/.github/workflows/faktorybuildbranches.yml@v0.7
+    with: 
+      netrcMachine: touchlabartifactory.jfrog.io
+    secrets:
+      PODSPEC_SSH_KEY: ${{ secrets.PODSPEC_SSH_KEY }}
+      gradle_params: -PUSERNAME=${{ secrets.ARTIFACTORY_USERNAME}} -PPASSWORD=${{ secrets.ARTIFACTORY_PASSWORD }}
+```
+
+or set them separately like this:
+
+```yaml
+jobs:
+  call-kmmbridge-publish:
+    uses: touchlab/KMMBridgeGithubWorkflow/.github/workflows/faktorybuildbranches.yml@v0.7
+    with: 
+      netrcMachine: touchlabartifactory.jfrog.io
+    secrets:
+      PODSPEC_SSH_KEY: ${{ secrets.PODSPEC_SSH_KEY }}
+      netrcUsername: ${{ secrets.ARTIFACTORY_USERNAME }} 
+      netrcPassword: ${{ secrets.ARTIFACTORY_PASSWORD }} 
+```

--- a/website/docs/ciconfig/01_GITHUB_ACTIONS.md
+++ b/website/docs/ciconfig/01_GITHUB_ACTIONS.md
@@ -62,7 +62,7 @@ There are 2 parameters, both are optional:
 * gradle_params - If your Gradle build needs custom params, like properties, pass them here.
 * PODSPEC_SSH_KEY - The SSH key for publishing.
 
-When publishing in a CI action you need to add the credentials to `~/.netrc` before running publish to validate the podspec. To do this simply pass the custom `netrc` params in our GitHub Workflow.
+When publishing in a CI action you need to add the credentials to `~/.netrc` before running publish, for example to validate the podspec or to authenticate to your artifact hosting. To do this simply pass the custom `netrc` params in our GitHub Workflow.
 
 You'll also need to add the username and password gradle params through the `gradle_params` secret in our workflow:
 


### PR DESCRIPTION
Issue: https://github.com/touchlab/KMMBridge/issues/179

## Summary
We added the ability to pass custom credentials in https://github.com/touchlab/KMMBridgeGithubWorkflow/pull/3/files

We describe usage of this on the Artifactory docs page, but we should also mention this in the docs page on CI.
