### PR TITLE
[#54] Check GITHUB_REPO arg to make sure it's just owner/repo

### DIFF
--- a/kmmbridge/src/main/kotlin/BuildFileHelper.kt
+++ b/kmmbridge/src/main/kotlin/BuildFileHelper.kt
@@ -11,9 +11,8 @@
  * the License.
  */
 
-import co.touchlab.faktory.githubPublishToken
+import co.touchlab.faktory.*
 import co.touchlab.faktory.githubPublishUser
-import co.touchlab.faktory.githubRepo
 import co.touchlab.faktory.publishingExtension
 import org.gradle.api.Project
 import java.net.URI
@@ -30,20 +29,16 @@ import java.net.URI
 @Suppress("unused")
 fun Project.addGithubPackagesRepository() {
     publishingExtension.apply {
-        try {
-            val githubPublishUser = project.githubPublishUser ?: "cirunner"
-            val githubPublishToken = project.githubPublishToken
-            val githubRepo = project.githubRepo
-            repositories.maven {
-                name = "GitHubPackages"
-                url = URI.create("https://maven.pkg.github.com/$githubRepo")
-                credentials {
-                    username = githubPublishUser
-                    password = githubPublishToken
-                }
+        val githubPublishUser = project.githubPublishUser ?: "cirunner"
+        val githubRepo = project.githubRepoOrNull ?: return
+        val githubPublishToken = project.githubPublishTokenOrNull ?: return
+        repositories.maven {
+            name = "GitHubPackages"
+            url = URI.create("https://maven.pkg.github.com/$githubRepo")
+            credentials {
+                username = githubPublishUser
+                password = githubPublishToken
             }
-        } catch (e: Exception) {
-            // Ignore
         }
     }
 }


### PR DESCRIPTION
Issue: https://github.com/touchlab/KMMBridge/issues/54

## Summary
Passing in the whole url, or presumably just the repo and not owner, will result in weird error messages.

The goal is to improve error messaging when an invalid value is passed which informs them that the input must be "Owner/Repo"

## Fix
Added regex check for valid options for setting a github repo (such as url and ssh path), if regex is not matched, exception is thrown.

## Testing
Tested in KmmBridgeKickStart app by calling `./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN="$MY_TOKEN" -PGITHUB_REPO="https://github.com/touchlab/KMMBridgeKockStart.git" -PGITHUB_PUBLISH_USER="Touchlab-Bot" --no-daemon --stacktrace`
