### PR TITLE
[Issue-269] Test Manual Version Manager

### DIFF
--- a/.github/workflows/integration-test-manual-version.yml
+++ b/.github/workflows/integration-test-manual-version.yml
@@ -74,11 +74,17 @@ jobs:
         run: |
           ./gradlew publishToMavenLocal -PRELEASE_SIGNING_ENABLED=false -PVERSION_NAME=999 --info
 
+      - name: Calculate new version
+        run: |
+          eval timestamp=$(date +%s)
+          eval newVersion="1.0.$timestamp"
+          echo "VERSION=$newVersion" >> $GITHUB_ENV
+
       - name: Publish shared
         id: publish1
         run: |
           cd build/${{ env.TEST_URL }}
-          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }} -PGITHUB_REPO=touchlab/${{ env.TEST_URL }} -PGITHUB_PUBLISH_USER=${{ env.GITHUB_PUBLISH_USER }} -Pversion="3.3.5" --no-daemon --stacktrace
+          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }} -PGITHUB_REPO=touchlab/${{ env.TEST_URL }} -PGITHUB_PUBLISH_USER=${{ env.GITHUB_PUBLISH_USER }} -Pversion=${{ env.VERSION }} --no-daemon --stacktrace
         env:
           GRADLE_OPTS: -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=512m"
 
@@ -87,7 +93,7 @@ jobs:
         continue-on-error: true
         run: |
           cd build/${{ env.TEST_URL }}
-          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }} -PGITHUB_REPO=touchlab/${{ env.TEST_URL }} -PGITHUB_PUBLISH_USER=${{ env.GITHUB_PUBLISH_USER }} -Pversion="3.3.5" --no-daemon --stacktrace
+          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }} -PGITHUB_REPO=touchlab/${{ env.TEST_URL }} -PGITHUB_PUBLISH_USER=${{ env.GITHUB_PUBLISH_USER }} -Pversion=${{ env.VERSION }} --no-daemon --stacktrace
         env:
           GRADLE_OPTS: -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=512m"
 

--- a/.github/workflows/integration-test-manual-version.yml
+++ b/.github/workflows/integration-test-manual-version.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Publish shared
         run: |
           cd build/${{ env.TEST_URL }}
-          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }} -PGITHUB_REPO=touchlab/${{ env.TEST_URL }} -PGITHUB_PUBLISH_USER=${{ env.GITHUB_PUBLISH_USER }} --no-daemon --stacktrace
+          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }} -PGITHUB_REPO=touchlab/${{ env.TEST_URL }} -PGITHUB_PUBLISH_USER=${{ env.GITHUB_PUBLISH_USER }} -Pversion="3.3.3" --no-daemon --stacktrace
         env:
           GRADLE_OPTS: -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=512m"
 
@@ -85,7 +85,7 @@ jobs:
         continue-on-error: true
         run: |
           cd build/${{ env.TEST_URL }}
-          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }} -PGITHUB_REPO=touchlab/${{ env.TEST_URL }} -PGITHUB_PUBLISH_USER=${{ env.GITHUB_PUBLISH_USER }} --no-daemon --stacktrace
+          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }} -PGITHUB_REPO=touchlab/${{ env.TEST_URL }} -PGITHUB_PUBLISH_USER=${{ env.GITHUB_PUBLISH_USER }} -Pversion="3.3.3" --no-daemon --stacktrace
         env:
           GRADLE_OPTS: -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=512m"
 

--- a/.github/workflows/integration-test-manual-version.yml
+++ b/.github/workflows/integration-test-manual-version.yml
@@ -1,0 +1,101 @@
+name: "Integration Test Manual Version"
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "**/*.md"
+      - "website/**"
+  pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "website/**"
+  workflow_dispatch:
+      
+jobs:
+  build:
+    concurrency: "integration-test-manual-version"
+    runs-on: macos-12
+    env:
+      GITHUB_PUBLISH_USER: "Touchlab-Bot"
+      TEST_URL: "KmmBridgeManualVersionTest"
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "adopt"
+          java-version: "11"
+      
+      - name: "Checkout sample"
+        uses: actions/checkout@v3
+        with:
+          repository: "touchlab/${{ env.TEST_URL }}"
+          ref: main
+          path: "build/${{ env.TEST_URL }}"
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+        with:
+          min-wrapper-count: 2 # Validating both the local wrapper and the one in the cloned sample
+
+      - name: Apply SSH Key
+        uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # v0.7.0
+        with:
+          ssh-private-key: |
+            ${{ secrets.PODSPEC_SSH_KEY }}
+            ${{ secrets.INTEGRATION_TEST_MANUAL_VERSION_SSH_KEY }}
+
+      - uses: extractions/netrc@938ddbfb73b4efee33e57db13aba434b35af2f93 # v1
+        with:
+          machine: api.github.com
+          username: ${{ env.GITHUB_PUBLISH_USER }}
+          password: ${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }}
+
+      - uses: extractions/netrc@938ddbfb73b4efee33e57db13aba434b35af2f93 # v1
+        with:
+          machine: maven.pkg.github.com
+          username: ${{ env.GITHUB_PUBLISH_USER }}
+          password: ${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }}
+
+      - name: Cache build tooling
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.konan
+          key: ${{ runner.os }}-v4-${{ hashFiles('*.gradle.kts') }}
+
+
+      # TODO can we cache this so it only runs once instead of running for every test case?
+      - name: Local publish plugin
+        run: |
+          ./gradlew publishToMavenLocal -PRELEASE_SIGNING_ENABLED=false -PVERSION_NAME=999 --info
+
+      - name: Publish shared
+        run: |
+          cd build/${{ env.TEST_URL }}
+          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }} -PGITHUB_REPO=touchlab/${{ env.TEST_URL }} -PGITHUB_PUBLISH_USER=${{ env.GITHUB_PUBLISH_USER }} --no-daemon --stacktrace
+        env:
+          GRADLE_OPTS: -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=512m"
+
+      - name: Publish shared
+        continue-on-error: true
+        run: |
+          cd build/${{ env.TEST_URL }}
+          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }} -PGITHUB_REPO=touchlab/${{ env.TEST_URL }} -PGITHUB_PUBLISH_USER=${{ env.GITHUB_PUBLISH_USER }} --no-daemon --stacktrace
+        env:
+          GRADLE_OPTS: -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=512m"
+
+      - name: Build SPM Sample
+        run: |
+          cd build/${{ env.TEST_URL }}/ios-spm
+          xcodebuild -configuration Debug -scheme KmmBridgeIntegrationTestSpm -sdk iphonesimulator 
+
+      - name: Build Cocoapods Sample
+        run: |
+          cd build/${{ env.TEST_URL }}/ios-cocoapods
+          pod install
+          xcodebuild -workspace KmmBridgeIntegrationTestCocoapods.xcworkspace -configuration Debug -scheme KmmBridgeIntegrationTestCocoapods -sdk iphonesimulator

--- a/.github/workflows/integration-test-manual-version.yml
+++ b/.github/workflows/integration-test-manual-version.yml
@@ -75,19 +75,25 @@ jobs:
           ./gradlew publishToMavenLocal -PRELEASE_SIGNING_ENABLED=false -PVERSION_NAME=999 --info
 
       - name: Publish shared
+        id: publish1
         run: |
           cd build/${{ env.TEST_URL }}
-          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }} -PGITHUB_REPO=touchlab/${{ env.TEST_URL }} -PGITHUB_PUBLISH_USER=${{ env.GITHUB_PUBLISH_USER }} -Pversion="3.3.3" --no-daemon --stacktrace
+          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }} -PGITHUB_REPO=touchlab/${{ env.TEST_URL }} -PGITHUB_PUBLISH_USER=${{ env.GITHUB_PUBLISH_USER }} -Pversion="3.3.5" --no-daemon --stacktrace
         env:
           GRADLE_OPTS: -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=512m"
 
-      - name: Publish shared
+      - name: Publish shared again
+        id: publish2
         continue-on-error: true
         run: |
           cd build/${{ env.TEST_URL }}
-          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }} -PGITHUB_REPO=touchlab/${{ env.TEST_URL }} -PGITHUB_PUBLISH_USER=${{ env.GITHUB_PUBLISH_USER }} -Pversion="3.3.3" --no-daemon --stacktrace
+          ./gradlew kmmBridgePublish -PGITHUB_PUBLISH_TOKEN=${{ secrets.INTEGRATION_TEST_GITHUB_TOKEN }} -PGITHUB_REPO=touchlab/${{ env.TEST_URL }} -PGITHUB_PUBLISH_USER=${{ env.GITHUB_PUBLISH_USER }} -Pversion="3.3.5" --no-daemon --stacktrace
         env:
           GRADLE_OPTS: -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=512m"
+
+      - name: Check repeated fails
+        if: steps.publish1.outcome != 'success' || steps.publish2.outcome == 'success'
+        run: exit 1
 
       - name: Build SPM Sample
         run: |


### PR DESCRIPTION
Issue: https://github.com/touchlab/KMMBridge/issues/269

## Summary
Create integration test for using manual version to publish an artifact and confirm it exists. Confirm that if you try to publish the same version twice it fails. Confirm that if you increment the version manually it works

This will require some expansion of the existing integration test functionality because there currently isn't a hook we can use to set the new version as part of the CI flow.
