### PR TITLE
Enable path style access to s3 bucket. Also update dependencies!

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Touchlab.
+ * Copyright (c) 2023 Touchlab.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2022 Touchlab.
+# Copyright (c) 2020-2023 Touchlab.
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
 #
@@ -15,7 +15,7 @@ android.useAndroidX=true
 org.gradle.jvmargs=-Xmx2g
 
 GROUP=co.touchlab.faktory
-VERSION_NAME=0.3.5
+VERSION_NAME=0.3.51
 KOTLIN_VERSION=1.8.0
 
 POM_URL=https://github.com/touchlab/KMMBridge

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ android.useAndroidX=true
 org.gradle.jvmargs=-Xmx2g
 
 GROUP=co.touchlab.faktory
-VERSION_NAME=0.3.51
+VERSION_NAME=0.3.6
 KOTLIN_VERSION=1.8.0
 
 POM_URL=https://github.com/touchlab/KMMBridge

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022 Touchlab.
+# Copyright (c) 2023 Touchlab.
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
 #

--- a/kmmbridge/build.gradle.kts
+++ b/kmmbridge/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Touchlab.
+ * Copyright (c) 2023 Touchlab.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *
@@ -49,13 +49,13 @@ dependencies {
     implementation(kotlin("gradle-plugin"))
     implementation(kotlin("compiler-embeddable"))
 
-    implementation("javax.json:javax.json-api:1.1.4")
-    implementation("org.glassfish:javax.json:1.1.4")
+    implementation("jakarta.json:jakarta.json-api:2.1.1")
+    implementation("org.glassfish:jakarta.json:2.0.1")
     implementation("commons-codec:commons-codec:1.15")
-    implementation("software.amazon.awssdk:s3:2.17.276")
+    implementation("software.amazon.awssdk:s3:2.20.17")
 
     implementation("com.squareup.okhttp3:okhttp:4.10.0")
-    implementation("com.google.code.gson:gson:2.9.0")
+    implementation("com.google.code.gson:gson:2.10.1")
     testImplementation(kotlin("test"))
 }
 

--- a/kmmbridge/src/main/kotlin/BuildFileHelper.kt
+++ b/kmmbridge/src/main/kotlin/BuildFileHelper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Touchlab.
+ * Copyright (c) 2023 Touchlab.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *

--- a/kmmbridge/src/main/kotlin/KMMBridge.kt
+++ b/kmmbridge/src/main/kotlin/KMMBridge.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Touchlab.
+ * Copyright (c) 2023 Touchlab.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *

--- a/kmmbridge/src/main/kotlin/KmmBridgeExtension.kt
+++ b/kmmbridge/src/main/kotlin/KmmBridgeExtension.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Touchlab.
+ * Copyright (c) 2023 Touchlab.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *

--- a/kmmbridge/src/main/kotlin/ProjectExtensions.kt
+++ b/kmmbridge/src/main/kotlin/ProjectExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Touchlab.
+ * Copyright (c) 2023 Touchlab.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *

--- a/kmmbridge/src/main/kotlin/artifactmanager/ArtifactManager.kt
+++ b/kmmbridge/src/main/kotlin/artifactmanager/ArtifactManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Touchlab.
+ * Copyright (c) 2023 Touchlab.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *

--- a/kmmbridge/src/main/kotlin/artifactmanager/AwsS3PublicArtifactManager.kt
+++ b/kmmbridge/src/main/kotlin/artifactmanager/AwsS3PublicArtifactManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Touchlab.
+ * Copyright (c) 2023 Touchlab.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *
@@ -19,6 +19,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.S3Configuration
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import java.io.File
@@ -56,6 +57,7 @@ class AwsS3PublicArtifactManager(
     @Suppress("NAME_SHADOWING")
     private fun uploadArtifact(zipFilePath: File, fileName: String) {
         val s3Client = S3Client.builder()
+            .serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
             .region(Region.of(s3Region))
             .credentialsProvider {
                 AwsBasicCredentials.create(

--- a/kmmbridge/src/main/kotlin/artifactmanager/FaktoryServerArtifactManager.kt
+++ b/kmmbridge/src/main/kotlin/artifactmanager/FaktoryServerArtifactManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Touchlab.
+ * Copyright (c) 2023 Touchlab.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *

--- a/kmmbridge/src/main/kotlin/dependencymanager/CocoapodsDependencyManager.kt
+++ b/kmmbridge/src/main/kotlin/dependencymanager/CocoapodsDependencyManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Touchlab.
+ * Copyright (c) 2023 Touchlab.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *

--- a/kmmbridge/src/main/kotlin/dependencymanager/DependencyManager.kt
+++ b/kmmbridge/src/main/kotlin/dependencymanager/DependencyManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Touchlab.
+ * Copyright (c) 2023 Touchlab.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *

--- a/kmmbridge/src/main/kotlin/dependencymanager/SpmDependencyManager.kt
+++ b/kmmbridge/src/main/kotlin/dependencymanager/SpmDependencyManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Touchlab.
+ * Copyright (c) 2023 Touchlab.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *

--- a/kmmbridge/src/main/kotlin/internal/ArtifactManagerHelper.kt
+++ b/kmmbridge/src/main/kotlin/internal/ArtifactManagerHelper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Touchlab.
+ * Copyright (c) 2023 Touchlab.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *

--- a/kmmbridge/src/main/kotlin/internal/GithubApi.kt
+++ b/kmmbridge/src/main/kotlin/internal/GithubApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Touchlab.
+ * Copyright (c) 2023 Touchlab.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *

--- a/kmmbridge/src/main/kotlin/internal/GithubCalls.kt
+++ b/kmmbridge/src/main/kotlin/internal/GithubCalls.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Touchlab.
+ * Copyright (c) 2023 Touchlab.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *

--- a/kmmbridge/src/main/kotlin/internal/GithubEnterpriseCalls.kt
+++ b/kmmbridge/src/main/kotlin/internal/GithubEnterpriseCalls.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Touchlab.
+ * Copyright (c) 2023 Touchlab.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *

--- a/kmmbridge/src/main/kotlin/internal/ProcessHelper.kt
+++ b/kmmbridge/src/main/kotlin/internal/ProcessHelper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Touchlab.
+ * Copyright (c) 2023 Touchlab.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *

--- a/kmmbridge/src/main/kotlin/internal/VersionNumberHelper.kt
+++ b/kmmbridge/src/main/kotlin/internal/VersionNumberHelper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Touchlab.
+ * Copyright (c) 2023 Touchlab.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *

--- a/kmmbridge/src/main/kotlin/localdevmanager/LocalDevManager.kt
+++ b/kmmbridge/src/main/kotlin/localdevmanager/LocalDevManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Touchlab.
+ * Copyright (c) 2023 Touchlab.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *

--- a/kmmbridge/src/main/kotlin/versionmanager/GitRemoteVersionWriter.kt
+++ b/kmmbridge/src/main/kotlin/versionmanager/GitRemoteVersionWriter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Touchlab.
+ * Copyright (c) 2023 Touchlab.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *

--- a/kmmbridge/src/main/kotlin/versionmanager/GitTagBasedVersionManager.kt
+++ b/kmmbridge/src/main/kotlin/versionmanager/GitTagBasedVersionManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Touchlab.
+ * Copyright (c) 2023 Touchlab.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *

--- a/kmmbridge/src/main/kotlin/versionmanager/GitTagVersionManager.kt
+++ b/kmmbridge/src/main/kotlin/versionmanager/GitTagVersionManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Touchlab.
+ * Copyright (c) 2023 Touchlab.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *

--- a/kmmbridge/src/main/kotlin/versionmanager/GithubReleaseVersionWriter.kt
+++ b/kmmbridge/src/main/kotlin/versionmanager/GithubReleaseVersionWriter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Touchlab.
+ * Copyright (c) 2023 Touchlab.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *

--- a/kmmbridge/src/main/kotlin/versionmanager/ManualVersionManager.kt
+++ b/kmmbridge/src/main/kotlin/versionmanager/ManualVersionManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Touchlab.
+ * Copyright (c) 2023 Touchlab.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *

--- a/kmmbridge/src/main/kotlin/versionmanager/TimestampVersionManager.kt
+++ b/kmmbridge/src/main/kotlin/versionmanager/TimestampVersionManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Touchlab.
+ * Copyright (c) 2023 Touchlab.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *

--- a/kmmbridge/src/main/kotlin/versionmanager/VersionManager.kt
+++ b/kmmbridge/src/main/kotlin/versionmanager/VersionManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Touchlab.
+ * Copyright (c) 2023 Touchlab.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *

--- a/kmmbridge/src/main/kotlin/versionmanager/VersionWriter.kt
+++ b/kmmbridge/src/main/kotlin/versionmanager/VersionWriter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Touchlab.
+ * Copyright (c) 2023 Touchlab.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *

--- a/kmmbridge/src/test/kotlin/internal/VersionNumberHelperTest.kt
+++ b/kmmbridge/src/test/kotlin/internal/VersionNumberHelperTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Touchlab.
+ * Copyright (c) 2023 Touchlab.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Touchlab.
+ * Copyright (c) 2023 Touchlab.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *


### PR DESCRIPTION
## Summary

- Enable path style access to s3 client
- Update other dependency version
  -  move `javax` dependencies from new location so we can use latest versions
- Update copyright year to 2023 everywhere.