### PR TITLE
double quotes around cocoapods curl header

### DIFF
--- a/kmmbridge/src/main/kotlin/dependencymanager/CocoapodsDependencyManager.kt
+++ b/kmmbridge/src/main/kotlin/dependencymanager/CocoapodsDependencyManager.kt
@@ -140,7 +140,7 @@ private fun Project.generatePodspec(outputFile: File) = with(kotlin.cocoapods) {
             |    spec.source                   = { 
             |                                      :http => '${url}',
             |                                      :type => 'zip',
-            |                                      :headers => ['Accept: application/octet-stream']
+            |                                      :headers => ["'Accept: application/octet-stream'"]
             |                                    }
             |    spec.authors                  = ${authors.orEmpty().surroundWithSingleQuotesIfNeeded()}
             |    spec.license                  = ${license.orEmpty().surroundWithSingleQuotesIfNeeded()}


### PR DESCRIPTION
<!--- [Issue-XYZ] Add issue number and title to Title above -->

<!-- Add issue link -->
Issue: https://github.com/touchlab/KMMBridge/issues/224

## Summary
Patches cocoapods dependency manager curl header for use on self-hosted runners with different curl versions.

## Fix
Followed @TadeasKriz suggestion of adding double quotes around `["'Accept: application/octet-stream'"]`

## Testing
<!-- Remove any lines that were not performed -->
- `./gradlew test` PASSED
- `./gradlew build` PASSED
- manual testing PASSED 
We deployed a 0.3.8-SNAPSHOT from my fork to maven local and used it in our project on our self-hosted runner.  The curl command worked and pod lib lint was successful.   Please let me know if you have any questions.  Thanks!
