### PR TITLE
Add option for a custom suffix on Maven artifact names

### DIFF
--- a/kmmbridge/src/main/kotlin/KmmBridgeExtension.kt
+++ b/kmmbridge/src/main/kotlin/KmmBridgeExtension.kt
@@ -86,8 +86,8 @@ interface KmmBridgeExtension {
      * If using multiple repos, you can specify which one the `Package.swift` and/or podspec point to by
      * passing the name in here.
      */
-    fun Project.mavenPublishArtifacts(repository: String? = null, publication: String? = null) {
-        artifactManager.setAndFinalize(MavenPublishArtifactManager(this, publication, repository))
+    fun Project.mavenPublishArtifacts(repository: String? = null, publication: String? = null, artifactSuffix: String? = null) {
+        artifactManager.setAndFinalize(MavenPublishArtifactManager(this, publication, artifactSuffix, repository))
     }
 
     fun timestampVersions() {

--- a/kmmbridge/src/main/kotlin/artifactmanager/MavenPublishArtifactManager.kt
+++ b/kmmbridge/src/main/kotlin/artifactmanager/MavenPublishArtifactManager.kt
@@ -32,7 +32,7 @@ class MavenPublishArtifactManager(
         uploadTask: TaskProvider<Task>,
         kmmPublishTask: TaskProvider<Task>
     ) {
-        project.publishingExtension.publications.create(FRAMEWORK_PUBLICATION_NAME, MavenPublication::class.java) {
+        project.publishingExtension.publications.create(publicationName ?: FRAMEWORK_PUBLICATION_NAME, MavenPublication::class.java) {
             this.version = version
             val archiveProvider = project.tasks.named("zipXCFramework", Zip::class.java).flatMap {
                 it.archiveFile

--- a/kmmbridge/src/main/kotlin/artifactmanager/MavenPublishArtifactManager.kt
+++ b/kmmbridge/src/main/kotlin/artifactmanager/MavenPublishArtifactManager.kt
@@ -20,10 +20,11 @@ private const val KMMBRIDGE_ARTIFACT_SUFFIX = "kmmbridge"
 class MavenPublishArtifactManager(
     val project: Project,
     private val publicationName: String?,
-    private val repositoryName: String?
-) : ArtifactManager {
+    artifactSuffix: String?,
+    private val repositoryName: String?,
+    ) : ArtifactManager {
     private val group: String = project.group.toString().replace(".", "/")
-    private val kmmbridgeArtifactId = "${project.name}-$KMMBRIDGE_ARTIFACT_SUFFIX"
+    private val kmmbridgeArtifactId = "${project.name}-${artifactSuffix ?: KMMBRIDGE_ARTIFACT_SUFFIX}"
 
     override fun configure(
         project: Project,


### PR DESCRIPTION
## Summary
Wanted ability to adjust the `-kmmbridge` suffix that was being appended to artifacts when published to a Maven repo.

## Fix
- Added optional parameter `artifactSuffix` to `MavenPublishArtifactManager` constructor and used it, if present, when setting `kmmbridgeArtifactId`
- Also added check for the optional parameter `publicationName` when creating the MavenPublication object

## Testing
- `./gradlew test`
- `./gradlew build`
- manual testing
