### PR TITLE
fix(#235): spm should support custom tools version and platforms

### DIFF
--- a/kmmbridge/src/main/kotlin/co/touchlab/faktory/KmmBridgeExtension.kt
+++ b/kmmbridge/src/main/kotlin/co/touchlab/faktory/KmmBridgeExtension.kt
@@ -18,6 +18,7 @@ import co.touchlab.faktory.artifactmanager.AwsS3PublicArtifactManager
 import co.touchlab.faktory.artifactmanager.MavenPublishArtifactManager
 import co.touchlab.faktory.dependencymanager.CocoapodsDependencyManager
 import co.touchlab.faktory.dependencymanager.DependencyManager
+import co.touchlab.faktory.dependencymanager.SpmConfig
 import co.touchlab.faktory.dependencymanager.SpecRepo
 import co.touchlab.faktory.dependencymanager.SpmDependencyManager
 import co.touchlab.faktory.versionmanager.ManualVersionManager
@@ -90,8 +91,10 @@ interface KmmBridgeExtension {
     fun Project.spm(
         spmDirectory: String? = null,
         useCustomPackageFile: Boolean = false,
+        config: SpmConfig.() -> Unit
     ) {
-        val dependencyManager = SpmDependencyManager(spmDirectory, useCustomPackageFile)
+        val spmConfig = SpmConfig().apply(config)
+        val dependencyManager = SpmDependencyManager(spmDirectory, useCustomPackageFile, spmConfig)
         dependencyManagers.set(dependencyManagers.getOrElse(emptyList()) + dependencyManager)
         localDevManager.setAndFinalize(dependencyManager)
     }


### PR DESCRIPTION
<!--- [Issue-XYZ] Add issue number and title to Title above -->
[Issue-235] spm should support custom tools version and platforms
<!-- Add issue link -->
Issue: https://github.com/touchlab/KMMBridge/issues/235

## Summary
allow custom swiftToolsVersion and platforms

## Fix
```
kmmbridge {
    mavenPublishArtifacts()
    frameworkName.set("shared")
    spm {
        swiftToolsVersion = "5.9"
        platforms = listOf(".iOS(.v13)", ".macOS(.v13)")
    }
    //etc
}
```

## Testing
<!-- Remove any lines that were not performed -->
- `./gradlew test`
- `./gradlew build`
- manual testing
