### PR TITLE
Extended GitLab Publishing for self managed instances #249

### DIFF
--- a/kmmbridge/src/main/kotlin/co/touchlab/faktory/internal/GitLabApi.kt
+++ b/kmmbridge/src/main/kotlin/co/touchlab/faktory/internal/GitLabApi.kt
@@ -17,16 +17,19 @@ import co.touchlab.faktory.findStringProperty
 import org.gradle.api.Project
 import java.net.URLEncoder
 
-internal val Project.gitlabPublishTokenOrNull: String?
+internal val Project.gitLabPublishTokenOrNull: String?
     get() = project.property("GITLAB_PUBLISH_TOKEN") as String?
 
-internal val Project.gitlabPublishUser: String?
+internal val Project.gitLabPublishUser: String?
     get() = project.findStringProperty("GITLAB_PUBLISH_USER")
 
-internal val Project.gitlabRepoOrNull: String?
+internal val Project.gitLabRepoOrNull: String?
     get() {
         val repo = project.findStringProperty("GITHUB_REPO") ?: return null
         // The GitLab API accepts repo id or url-encoded path
         val repoId = repo.toIntOrNull()
         return repoId?.toString() ?: URLEncoder.encode(repo, "UTF-8")
     }
+
+internal val Project.gitLabDomain: String?
+    get() = project.findStringProperty("GITLAB_DOMAIN")


### PR DESCRIPTION
Issue: https://github.com/touchlab/KMMBridge/issues/249

## Summary
The GitLab domain in the Maven config is fixed to gitlab.com and can't be configured for self-hosted e.g. gitlab.companyname.com

## Fix
* The GitLab domain can now be specified by optionally setting the `GITLAB_DOMAIN` property which is necessary if you need to publish to a self-managed instance.
* Corrected minor casing typos.
* Added logging of exception for easier problem diagnosis when there's an issue with the GitLab repo settings.

## Testing
<!-- Remove any lines that were not performed -->
- `./gradlew test`
- `./gradlew build`
- manual testing
