### PR TITLE
Allowing multiple packages in the same package.swift file

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ org.gradle.jvmargs=-Xmx4g
 #RELEASE_SIGNING_ENABLED=false
 
 GROUP=co.touchlab.kmmbridge
-VERSION_NAME=0.5.6
+VERSION_NAME=0.5.7-SNAPSHOT
 VERSION_NAME_3x=0.3.7
 
 POM_URL=https://github.com/touchlab/KMMBridge

--- a/kmmbridge/src/main/kotlin/co/touchlab/faktory/KmmBridgeExtension.kt
+++ b/kmmbridge/src/main/kotlin/co/touchlab/faktory/KmmBridgeExtension.kt
@@ -93,16 +93,18 @@ interface KmmBridgeExtension {
      *
      * @param spmDirectory Folder where the Package.swift file lives
      * @param useCustomPackageFile Allow to use custom Package.swift file
+     * @param perModuleVariablesBlock Allow the same Package.swift file to host multiple kotlin frameworks
      * @param swiftToolVersion Specifies swift-tools-version in Package.swift. Default: [SwiftToolVersion.Default]
      */
     @Suppress("unused")
     fun Project.spm(
         spmDirectory: String? = null,
         useCustomPackageFile: Boolean = false,
+        perModuleVariablesBlock: Boolean = false,
         swiftToolVersion: String = SwiftToolVersion.Default,
         targetPlatforms: TargetPlatformDsl.() -> Unit = { iOS { v("13") } },
     ) {
-        val dependencyManager = SpmDependencyManager(spmDirectory, useCustomPackageFile, swiftToolVersion, targetPlatforms)
+        val dependencyManager = SpmDependencyManager(spmDirectory, useCustomPackageFile, perModuleVariablesBlock, swiftToolVersion, targetPlatforms)
         dependencyManagers.set(dependencyManagers.getOrElse(emptyList()) + dependencyManager)
         localDevManager.setAndFinalize(dependencyManager)
     }

--- a/kmmbridge/src/test/kotlin/co/touchlab/faktory/dependencyManager/PackageFileUpdateTest.kt
+++ b/kmmbridge/src/test/kotlin/co/touchlab/faktory/dependencyManager/PackageFileUpdateTest.kt
@@ -74,6 +74,7 @@ class PackageFileUpdateTest {
         val newFile = getModifiedPackageFileText(
             oldFile,
             "TestPackage",
+            false,
             "https://www.example.com/",
             "fedcba9876543210"
         )
@@ -105,6 +106,95 @@ class PackageFileUpdateTest {
         val newFile = getModifiedPackageFileText(
             oldFile,
             "TestPackage",
+            false,
+            "https://www.example.com/",
+            "fedcba9876543210"
+        )
+        assertEquals(expectedNewFile, newFile)
+    }
+
+    @Test
+    fun withMultipleModules() {
+        val oldFile = """
+            // swift-tools-version:5.3
+            import PackageDescription
+
+            // BEGIN KMMBRIDGE VARIABLES BLOCK FOR 'TestPackage' (do not edit)
+            let remoteTestPackageUrl = "https://www.example.com/"
+            let remoteTestPackageChecksum = "01234567890abcdef"
+            let testPackagePackageName = "TestPackage"
+            // END KMMBRIDGE BLOCK FOR 'TestPackage'
+
+            // BEGIN KMMBRIDGE VARIABLES BLOCK FOR 'TestPackage2' (do not edit)
+            let remoteTestPackageUrl = "https://www.example.com/"
+            let remoteTestPackageChecksum = "01234567890abcdeg"
+            let testPackagePackageName = "TestPackage2"
+            // END KMMBRIDGE BLOCK FOR 'TestPackage2'
+
+            let package = Package(
+                name: packageName,
+                platforms: [
+                    .iOS(.v13)
+                ],
+                products: [
+                    .library(
+                        name: packageName,
+                        targets: [packageName]
+                    ),
+                ],
+                targets: [
+                    .binaryTarget(
+                        name: packageName,
+                        url: remoteKotlinUrl,
+                        checksum: remoteKotlinChecksum
+                    )
+                    ,
+                ]
+            )
+        """.trimIndent()
+
+        val expectedNewFile = """
+            // swift-tools-version:5.3
+            import PackageDescription
+
+            // BEGIN KMMBRIDGE VARIABLES BLOCK FOR 'TestPackage' (do not edit)
+            let remoteTestPackageUrl = "https://www.example.com/"
+            let remoteTestPackageChecksum = "fedcba9876543210"
+            let testPackagePackageName = "TestPackage"
+            // END KMMBRIDGE BLOCK FOR 'TestPackage'
+
+            // BEGIN KMMBRIDGE VARIABLES BLOCK FOR 'TestPackage2' (do not edit)
+            let remoteTestPackageUrl = "https://www.example.com/"
+            let remoteTestPackageChecksum = "01234567890abcdeg"
+            let testPackagePackageName = "TestPackage2"
+            // END KMMBRIDGE BLOCK FOR 'TestPackage2'
+
+            let package = Package(
+                name: packageName,
+                platforms: [
+                    .iOS(.v13)
+                ],
+                products: [
+                    .library(
+                        name: packageName,
+                        targets: [packageName]
+                    ),
+                ],
+                targets: [
+                    .binaryTarget(
+                        name: packageName,
+                        url: remoteKotlinUrl,
+                        checksum: remoteKotlinChecksum
+                    )
+                    ,
+                ]
+            )
+        """.trimIndent()
+
+        val newFile = getModifiedPackageFileText(
+            oldFile,
+            "TestPackage",
+            true,
             "https://www.example.com/",
             "fedcba9876543210"
         )


### PR DESCRIPTION
<!--- [Issue-XYZ] Add issue number and title to Title above -->

<!-- Add issue link -->
Issue: https://github.com/touchlab/KMMBridge/issues/168

## Summary
- We must support having multiple framework declarations in the same Package.swift file

## Fix
- Created an extra property to the SPM configuration called `perModuleVariablesBlock`
  - This parameter works together with the `useCustomPackageFile`
  - When it's set to true, each configuration block will mention the package name it's publishing so it knows which block should be updated.
    - Check `withMultipleModules` test case

## Testing
- `./gradlew test`
- `./gradlew build`
