### PR TITLE
Correct URLs for Maven Central artifacts

### DIFF
--- a/kmmbridge/src/main/kotlin/co/touchlab/faktory/KmmBridgeExtension.kt
+++ b/kmmbridge/src/main/kotlin/co/touchlab/faktory/KmmBridgeExtension.kt
@@ -74,8 +74,8 @@ interface KmmBridgeExtension {
      * the name in here.
      */
     @Suppress("unused")
-    fun Project.mavenPublishArtifacts(repository: String? = null, publication: String? = null, artifactSuffix: String? = null) {
-        artifactManager.setAndFinalize(MavenPublishArtifactManager(this, publication, artifactSuffix, repository))
+    fun Project.mavenPublishArtifacts(repository: String? = null, publication: String? = null, artifactSuffix: String? = null, isMavenCentral: Boolean = false) {
+        artifactManager.setAndFinalize(MavenPublishArtifactManager(this, publication, artifactSuffix, repository, isMavenCentral))
     }
 
     @Suppress("unused")

--- a/kmmbridge/src/main/kotlin/co/touchlab/faktory/artifactmanager/MavenPublishArtifactManager.kt
+++ b/kmmbridge/src/main/kotlin/co/touchlab/faktory/artifactmanager/MavenPublishArtifactManager.kt
@@ -22,6 +22,7 @@ class MavenPublishArtifactManager(
     private val publicationName: String?,
     artifactSuffix: String?,
     private val repositoryName: String?,
+    private val isMavenCentral: Boolean = false,
     ) : ArtifactManager {
     private val group: String = project.group.toString().replace(".", "/")
     private val kmmbridgeArtifactId = "${project.name}-${artifactSuffix ?: KMMBRIDGE_ARTIFACT_SUFFIX}"
@@ -73,8 +74,11 @@ class MavenPublishArtifactManager(
         // There may be more than one repo, but it's also possible we get none. This will allow us to continue and trying
         // to use the dependency should fail.
         // If there are multiple repos, the repo name needs to be specified.
-        val mavenArtifactRepositoryUrl =
+        val mavenArtifactRepositoryUrl = if (!isMavenCentral) {
             findArtifactRepository(publishingExtension).url.toString()
+        } else {
+            "https://repo.maven.apache.org/maven2/"
+        }
 
         return artifactPath(mavenArtifactRepositoryUrl, version)
     }


### PR DESCRIPTION
## Summary
Existing workflows publishing to the "new" Maven Central pre-publish artifacts to a `file:` location and therefore have that set on the `MavenArtifactRepository.url` property

See e.g. this implementation on the gradle maven publishing plugin: https://github.com/vanniktech/gradle-maven-publish-plugin/blob/da599468864f7be7f0c694f174baa797ba8bf189/plugin/src/main/kotlin/com/vanniktech/maven/publish/sonatype/SonatypeRepositoryBuildService.kt#L198

## Fix
Instead of trying to detect this scenario, this exposes the option to manually configure an `isMavenCentral` property of the `MavenPublishArtifactManager`. The user then sets this when configuring maven i.e. 

```
kmmbridge {
    mavenPublishArtifacts(isMavenCentral = true)
    ...
}
```

## Testing
Have not performed manual testing (but have implemented similar solution in another plugin)
