### PR TITLE
Use `releaseRepository` in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Finish Maven Central Release
-        run: ./gradlew closeAndReleaseRepository --no-daemon --stacktrace --no-build-cache
+        run: ./gradlew releaseRepository --no-daemon --stacktrace --no-build-cache
         env:
           ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}


### PR DESCRIPTION
This was replaced in the vanniktech plugin as of 0.28.0 https://vanniktech.github.io/gradle-maven-publish-plugin/changelog/#0280-2024-03-12

Fixes the _apparent_ release action failures e.g. https://github.com/touchlab/KMMBridge/actions/runs/10689342756/job/29631221033

