### PR TITLE
Read parameter to set default native build type

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ SONATYPE_HOST=DEFAULT
 RELEASE_SIGNING_ENABLED=true
 
 GROUP=co.touchlab.kmmbridge
-VERSION_NAME=1.1.0
+VERSION_NAME=1.1.1
 VERSION_NAME_3x=0.3.7
 
 POM_URL=https://github.com/touchlab/KMMBridge

--- a/kmmbridge/src/main/kotlin/co/touchlab/kmmbridge/KMMBridge.kt
+++ b/kmmbridge/src/main/kotlin/co/touchlab/kmmbridge/KMMBridge.kt
@@ -52,7 +52,14 @@ abstract class BaseKMMBridgePlugin : Plugin<Project> {
         val extension = extensions.create<KmmBridgeExtension>(EXTENSION_NAME)
 
         extension.dependencyManagers.convention(emptyList())
-        extension.buildType.convention(NativeBuildType.RELEASE)
+
+        val defaultNativeBuildType = if (project.findStringProperty("NATIVE_BUILD_TYPE") == "DEBUG") {
+            NativeBuildType.DEBUG
+        } else {
+            NativeBuildType.RELEASE
+        }
+
+        extension.buildType.convention(defaultNativeBuildType)
 
         afterEvaluate {
             val kmmBridgeExtension = extensions.getByType<KmmBridgeExtension>()

--- a/kmmbridge/src/main/kotlin/co/touchlab/kmmbridge/KmmBridgeExtension.kt
+++ b/kmmbridge/src/main/kotlin/co/touchlab/kmmbridge/KmmBridgeExtension.kt
@@ -42,7 +42,6 @@ interface KmmBridgeExtension {
 
     val buildType: Property<NativeBuildType>
 
-
     @Suppress("unused")
     fun Project.s3PublicArtifacts(
         region: String,


### PR DESCRIPTION
Add Gradle param to support setting native build type from the command line. Allows for simpler build CI workflows for development.