### PR TITLE
Use ValueSource to run pod commands for CocoaPods publishing

### DIFF
--- a/kmmbridge/src/main/kotlin/co/touchlab/kmmbridge/dependencymanager/CocoapodsDependencyManager.kt
+++ b/kmmbridge/src/main/kotlin/co/touchlab/kmmbridge/dependencymanager/CocoapodsDependencyManager.kt
@@ -294,7 +294,7 @@ private fun generatePodspec(
             |    spec.source                   = { 
             |                                      :http => '${url}',
             |                                      :type => 'zip',
-            |                                      :headers => ["'Accept: application/octet-stream'"]
+            |                                      :headers => ["Accept: application/octet-stream"]
             |                                    }
             |    spec.authors                  = ${
             authors.orEmpty().surroundWithSingleQuotesIfNeeded()


### PR DESCRIPTION
<!--- [Issue-XYZ] Add issue number and title to Title above -->

<!-- Add issue link -->
Issue: https://github.com/touchlab/KMMBridge/issues/267

## Summary
<!--- Copy summary from issue link or write a shortened description of it -->
Moving pod calls to use a ValueSource.

## Fix
* Using a ValueSource instead
* If there's an `exitValue` error, we catch it and then throw the underlying error
* Some formatting

## Testing
<!-- Remove any lines that were not performed -->
- `./gradlew test`
- `./gradlew build`
- manual testing


before
```
> Task :allshared:pushRemotePodspec FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':allshared:pushRemotePodspec'.
> Process 'command 'pod'' finished with non-zero exit value 1

* Try:
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

* Exception is:
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':allshared:pushRemotePodspec'.
Caused by: org.gradle.process.internal.ExecException: Process 'command 'pod'' finished with non-zero exit value 1
        at org.gradle.process.internal.DefaultExecHandle$ExecResultImpl.assertNormalExitValue(DefaultExecHandle.java:442)
        at org.gradle.process.internal.DefaultExecAction.execute(DefaultExecAction.java:38)
        at org.gradle.process.internal.DefaultExecActionFactory.exec(DefaultExecActionFactory.java:202)
        at org.gradle.process.internal.DefaultExecOperations.exec(DefaultExecOperations.java:37)
        at org.gradle.api.internal.provider.sources.process.ProcessOutputValueSource.obtain(ProcessOutputValueSource.java:123)
        at org.gradle.api.internal.provider.sources.process.ProcessOutputValueSource.obtain(ProcessOutputValueSource.java:37)
        at org.gradle.api.internal.provider.DefaultValueSourceProviderFactory$LazilyObtainedValue.lambda$new$0(DefaultValueSourceProviderFactory.java:294)
        at org.gradle.internal.model.CalculatedValueContainerFactory$SupplierBackedCalculator.calculateValue(CalculatedValueContainerFactory.java:78)
        at org.gradle.internal.model.CalculatedValueContainer$CalculationState.lambda$attachValue$0(CalculatedValueContainer.java:228)
        at org.gradle.internal.Try.ofFailable(Try.java:50)
        at org.gradle.internal.model.CalculatedValueContainer$CalculationState.attachValue(CalculatedValueContainer.java:223)
        at org.gradle.internal.model.CalculatedValueContainer.finalizeIfNotAlready(CalculatedValueContainer.java:194)
        at org.gradle.internal.model.CalculatedValueContainer.finalizeIfNotAlready(CalculatedValueContainer.java:185)
        at org.gradle.api.internal.provider.DefaultValueSourceProviderFactory$LazilyObtainedValue.obtain(DefaultValueSourceProviderFactory.java:309)
        at org.gradle.api.internal.provider.DefaultValueSourceProviderFactory$ValueSourceProvider.calculateOwnValue(DefaultValueSourceProviderFactory.java:261)
        at org.gradle.api.internal.provider.AbstractMinimalProvider.calculateValue(AbstractMinimalProvider.java:115)
        at org.gradle.api.internal.provider.TransformBackedProvider.calculateOwnValue(TransformBackedProvider.java:81)
        at org.gradle.api.internal.provider.AbstractMinimalProvider.calculateValue(AbstractMinimalProvider.java:115)
        at org.gradle.api.internal.provider.TransformBackedProvider.calculateOwnValue(TransformBackedProvider.java:81)
        at org.gradle.api.internal.provider.AbstractMinimalProvider.calculateOwnPresentValue(AbstractMinimalProvider.java:80)
        at org.gradle.api.internal.provider.AbstractMinimalProvider.get(AbstractMinimalProvider.java:100)
        at co.touchlab.kmmbridge.dependencymanager.CocoapodsDependencyManager$configure$pushRemotePodspecTask$1$2.execute(CocoapodsDependencyManager.kt:155)
        at co.touchlab.kmmbridge.dependencymanager.CocoapodsDependencyManager$configure$pushRemotePodspecTask$1$2.execute(CocoapodsDependencyManager.kt:122)

```


after
```
> Task :allshared:pushRemotePodspec FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':allshared:pushRemotePodspec'.
> Cloning spec repo `kevinschildhorn-kmmbridgetest_pods` from `git@github.com:KevinSchildhorn/KMMBridgeTest_Pods.git`
  [!] Unable to find the `git@github.com:KevinSchildhorn/KMMBridgeTest_Pods.git` repo. If it has not yet been cloned, add it via `pod repo add`.


* Try:
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

* Exception is:
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':allshared:pushRemotePodspec'.
Caused by: org.gradle.process.internal.ExecException: Cloning spec repo `kevinschildhorn-kmmbridgetest_pods` from `git@github.com:KevinSchildhorn/KMMBridgeTest_Pods.git`
[!] Unable to find the `git@github.com:KevinSchildhorn/KMMBridgeTest_Pods.git` repo. If it has not yet been cloned, add it via `pod repo add`.

        at co.touchlab.kmmbridge.dependencymanager.PodPushValueSource.obtain(CocoapodsDependencyManager.kt:85)
        at co.touchlab.kmmbridge.dependencymanager.PodPushValueSource.obtain(CocoapodsDependencyManager.kt:66)
        at org.gradle.api.internal.provider.DefaultValueSourceProviderFactory$LazilyObtainedValue.lambda$new$0(DefaultValueSourceProviderFactory.java:294)
```