### PR TITLE
Removed remote server for tests

### DIFF
--- a/.github/scripts/test-artifact-server.js
+++ b/.github/scripts/test-artifact-server.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * Throwaway stand-in for Touchlab's private test-artifact server (api.touchlab.dev).
+ *
+ * Implements just the two endpoints KMMBridge's TestUploadArtifactManager needs:
+ *   POST /store   -> stores the request body, returns {"url": "/infoadmin/streamTestZip/<id>.zip"}
+ *   GET  /file/<id>.zip -> serves the stored bytes back
+ *
+ * Used by build_mac.yml so CI (including fork PRs, which never get repo secrets)
+ * can exercise the real upload/download round-trip.
+ */
+const http = require("http");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const crypto = require("crypto");
+
+const STORAGE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "kmmbridge-test-artifacts-"));
+
+function log(message) {
+  process.stderr.write(`[test-artifact-server] ${message}\n`);
+}
+
+const server = http.createServer((req, res) => {
+  log(`${req.method} ${req.url}`);
+
+  if (req.method === "POST" && req.url === "/store") {
+    const chunks = [];
+    req.on("data", (chunk) => chunks.push(chunk));
+    req.on("end", () => {
+      const body = Buffer.concat(chunks);
+      const fileId = `${crypto.randomUUID()}.zip`;
+      fs.writeFileSync(path.join(STORAGE_DIR, fileId), body);
+
+      const reply = JSON.stringify({ url: `/file/${fileId}` });
+      res.writeHead(200, {
+        "Content-Type": "application/json",
+        "Content-Length": Buffer.byteLength(reply),
+      });
+      res.end(reply);
+    });
+    return;
+  }
+
+  const prefix = "/file/";
+  if (req.method === "GET" && req.url.startsWith(prefix)) {
+    const fileId = req.url.slice(prefix.length);
+    const filePath = path.join(STORAGE_DIR, fileId);
+    if (fileId.includes("..") || !fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+
+    const data = fs.readFileSync(filePath);
+    res.writeHead(200, {
+      "Content-Type": "application/octet-stream",
+      "Content-Length": data.length,
+    });
+    res.end(data);
+    return;
+  }
+
+  res.writeHead(404);
+  res.end();
+});
+
+const port = process.argv[2] ? parseInt(process.argv[2], 10) : 8089;
+server.listen(port, "127.0.0.1", () => {
+  console.log(`[test-artifact-server] listening on 127.0.0.1:${port}, storage=${STORAGE_DIR}`);
+});

--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -19,11 +19,11 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Write Faktory Server Code
-        run: echo ${{ secrets.TOUCHLAB_TEST_ARTIFACT_CODE }} > kmmbridge/TOUCHLAB_TEST_ARTIFACT_CODE
-
-      - name: Read Faktory Server Code
-        run: cat kmmbridge/TOUCHLAB_TEST_ARTIFACT_CODE
+      - name: Start local test artifact server
+        run: |
+          nohup node .github/scripts/test-artifact-server.js 8089 > /tmp/test-artifact-server.log 2>&1 &
+          disown
+          npx --yes wait-on tcp:127.0.0.1:8089
 
       - name: Local Publish For Tests
         run: ./gradlew publishToMavenLocal --no-daemon --stacktrace --build-cache -PRELEASE_SIGNING_ENABLED=false -PVERSION_NAME=9.9.9

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ build
 !/.idea/codeStyles/*
 !/.idea/inspectionProfiles/*
 .kotlin
-TOUCHLAB_TEST_ARTIFACT_CODE

--- a/TESTING.md
+++ b/TESTING.md
@@ -8,6 +8,18 @@ To do that, we need to locally publish KMMBridge, then point tests projects at t
 * A sample app project is copied to that folder
 * A command line process is run, generally running Gradle to perform whatever task we intend to test
 
+## Starting the local test artifact server
+
+`ArtifactManagerTest`, `SpmLocalDevTest`, and `NonKmmBridgeTasksTest` upload/download through a mock
+artifact server hardcoded to `http://127.0.0.1:8089` (see `kmmbridge-test`'s `TestUploadArtifactManager`).
+Before running these tests, start it in a separate terminal:
+
+```shell
+node .github/scripts/test-artifact-server.js 8089
+```
+
+Leave it running for the duration of your test run.
+
 ## Publishing KMMBridge locally
 
 We want to publish KMMBridge as version `9.9.9`. This is a fake local version, just for testing. To do that, run the following on the root folder of KMMBridge:

--- a/kmmbridge-test/src/main/kotlin/Extensions.kt
+++ b/kmmbridge-test/src/main/kotlin/Extensions.kt
@@ -1,8 +1,6 @@
-import co.touchlab.kmmbridge.findStringProperty
 import co.touchlab.kmmbridge.test.TestArtifactManager
 import co.touchlab.kmmbridge.test.TestUploadArtifactManager
 import co.touchlab.kmmbridge.test.kmmBridgeExtension
-import org.gradle.api.GradleException
 import org.gradle.api.Project
 
 @Suppress("unused")
@@ -17,16 +15,7 @@ fun Project.testArtifacts() {
  */
 @Suppress("unused")
 fun Project.testUploadArtifacts() {
-    val server = findStringProperty("TOUCHLAB_TEST_ARTIFACT_SERVER")
-    val code = findStringProperty("TOUCHLAB_TEST_ARTIFACT_CODE")
-
-    if (server == null || code == null) {
-        throw GradleException("TODO: Figure out a way for forks to not fail builds. But not today...")
-    }
-
-    val am = TestUploadArtifactManager(server, code)
-
     val artifactManager = kmmBridgeExtension.artifactManager
-    artifactManager.set(am)
+    artifactManager.set(TestUploadArtifactManager())
     artifactManager.finalizeValue()
 }

--- a/kmmbridge-test/src/main/kotlin/co/touchlab/kmmbridge/test/TestUploadArtifactManager.kt
+++ b/kmmbridge-test/src/main/kotlin/co/touchlab/kmmbridge/test/TestUploadArtifactManager.kt
@@ -16,7 +16,7 @@ import org.gradle.api.Task
  * Simple artifact manager that posts files to our server (Touchlab). This isn't designed for general usage. Just for
  * our tests. If there is more general demand for this functionality, reach out and we'll discuss ways of making it work.
  */
-internal class TestUploadArtifactManager() : ArtifactManager {
+internal class TestUploadArtifactManager : ArtifactManager {
     private val server: String = "http://127.0.0.1:8089"
 
     override fun deployArtifact(task: Task, zipFilePath: File, version: String): String {

--- a/kmmbridge-test/src/main/kotlin/co/touchlab/kmmbridge/test/TestUploadArtifactManager.kt
+++ b/kmmbridge-test/src/main/kotlin/co/touchlab/kmmbridge/test/TestUploadArtifactManager.kt
@@ -16,16 +16,17 @@ import org.gradle.api.Task
  * Simple artifact manager that posts files to our server (Touchlab). This isn't designed for general usage. Just for
  * our tests. If there is more general demand for this functionality, reach out and we'll discuss ways of making it work.
  */
-internal class TestUploadArtifactManager(private val server: String, private val code: String) : ArtifactManager {
+internal class TestUploadArtifactManager() : ArtifactManager {
+    private val server: String = "http://127.0.0.1:8089"
+
     override fun deployArtifact(task: Task, zipFilePath: File, version: String): String {
         val body: RequestBody = zipFilePath.asRequestBody("application/octet-stream".toMediaTypeOrNull())
         val uploadRequest =
             Request
                 .Builder()
                 .url(
-                    "https://$server/infoadmin/storeTestZip",
+                    "$server/store",
                 ).post(body)
-                .addHeader("code", code)
                 .addHeader("Content-Type", "application/octet-stream")
                 .build()
 
@@ -46,7 +47,7 @@ internal class TestUploadArtifactManager(private val server: String, private val
         val uploadResponseString = response.body!!.string()
         val url = Gson().fromJson(uploadResponseString, UploadReply::class.java).url
 
-        return "https://$server$url"
+        return "$server$url"
     }
 
     data class UploadReply(var url: String)

--- a/kmmbridge/src/test/kotlin/co/touchlab/kmmbridge/ArtifactManagerTest.kt
+++ b/kmmbridge/src/test/kotlin/co/touchlab/kmmbridge/ArtifactManagerTest.kt
@@ -14,8 +14,6 @@ class ArtifactManagerTest : BasePluginTest() {
         val result =
             ProcessHelper.runSh(
                 "./gradlew kmmBridgePublish " +
-                    "-PTOUCHLAB_TEST_ARTIFACT_SERVER=api.touchlab.dev " +
-                    "-PTOUCHLAB_TEST_ARTIFACT_CODE=${TOUCHLAB_TEST_ARTIFACT_CODE} " +
                     "--stacktrace",
                 workingDir = testProjectDir,
             )
@@ -31,8 +29,6 @@ class ArtifactManagerTest : BasePluginTest() {
             ProcessHelper.runSh(
                 "./gradlew clean kmmBridgePublish " +
                     "-PENABLE_PUBLISHING=true " +
-                    "-PTOUCHLAB_TEST_ARTIFACT_SERVER=api.touchlab.dev " +
-                    "-PTOUCHLAB_TEST_ARTIFACT_CODE=${TOUCHLAB_TEST_ARTIFACT_CODE} " +
                     "--stacktrace",
                 workingDir = testProjectDir,
             )
@@ -40,7 +36,7 @@ class ArtifactManagerTest : BasePluginTest() {
 
         assertTrue(urlFile.exists())
         val urlValue = urlFile.readText()
-        assertTrue(urlValue.startsWith("https://api.touchlab.dev/infoadmin/streamTestZip"))
+        assertTrue(urlValue.startsWith("http://127.0.0.1:8089/file"))
         assertEquals(0, result.status)
     }
 }

--- a/kmmbridge/src/test/kotlin/co/touchlab/kmmbridge/BasePluginTest.kt
+++ b/kmmbridge/src/test/kotlin/co/touchlab/kmmbridge/BasePluginTest.kt
@@ -16,14 +16,10 @@ abstract class BasePluginTest {
     internal lateinit var settingsFile: File
     internal lateinit var buildFile: File
 
-    @Suppress("ktlint:standard:property-naming")
-    internal lateinit var TOUCHLAB_TEST_ARTIFACT_CODE: String
-
     abstract fun testProjectPath(): String
 
     @BeforeEach
     fun setup() {
-        TOUCHLAB_TEST_ARTIFACT_CODE = File("TOUCHLAB_TEST_ARTIFACT_CODE").readText().lines().first()
         FileUtils.copyDirectory(testProjectSource, testProjectDir)
         ProcessHelper.runSh("git init;git add .;git commit -m 'arst'", workingDir = testProjectDir)
         settingsFile = File(testProjectDir, "settings.gradle.kts")

--- a/kmmbridge/src/test/kotlin/co/touchlab/kmmbridge/NonKmmBridgeTasksTest.kt
+++ b/kmmbridge/src/test/kotlin/co/touchlab/kmmbridge/NonKmmBridgeTasksTest.kt
@@ -13,9 +13,7 @@ class NonKmmBridgeTasksTest : BasePluginTest() {
     fun runBasicBuild() {
         val result =
             ProcessHelper.runSh(
-                "./gradlew linkDebugFrameworkIosSimulatorArm64 " +
-                    "-PTOUCHLAB_TEST_ARTIFACT_SERVER=api.touchlab.dev " +
-                    "-PTOUCHLAB_TEST_ARTIFACT_CODE=${TOUCHLAB_TEST_ARTIFACT_CODE}",
+                "./gradlew linkDebugFrameworkIosSimulatorArm64",
                 workingDir = testProjectDir,
             )
         logExecResult(result)

--- a/kmmbridge/src/test/kotlin/co/touchlab/kmmbridge/SpmLocalDevTest.kt
+++ b/kmmbridge/src/test/kotlin/co/touchlab/kmmbridge/SpmLocalDevTest.kt
@@ -10,9 +10,7 @@ class SpmLocalDevTest : BasePluginTest() {
     fun runSpmDevBuild() {
         val result =
             ProcessHelper.runSh(
-                "./gradlew spmDevBuild --stacktrace " +
-                    "-PTOUCHLAB_TEST_ARTIFACT_SERVER=api.touchlab.dev " +
-                    "-PTOUCHLAB_TEST_ARTIFACT_CODE=${TOUCHLAB_TEST_ARTIFACT_CODE}",
+                "./gradlew spmDevBuild --stacktrace",
                 workingDir = testProjectDir,
             )
         logExecResult(result)
@@ -27,9 +25,7 @@ class SpmLocalDevTest : BasePluginTest() {
         ProcessHelper.runSh("rm -rdf .git", workingDir = testProjectDir)
         val result =
             ProcessHelper.runSh(
-                "./gradlew spmDevBuild --stacktrace " +
-                    "-PTOUCHLAB_TEST_ARTIFACT_SERVER=api.touchlab.dev " +
-                    "-PTOUCHLAB_TEST_ARTIFACT_CODE=${TOUCHLAB_TEST_ARTIFACT_CODE}",
+                "./gradlew spmDevBuild --stacktrace",
                 workingDir = testProjectDir,
             )
         logExecResult(result)


### PR DESCRIPTION
- Removed remote server used for testing as nothing is ever consumed
- Using `testArtifacts()` configuration instead, as that does not need a server at all
- Fixed `spmDirectory` parameter, as it was generating the file in the project root during tests